### PR TITLE
Cleaning: Removed redundant tools KMERFinder & Resistance Genes Detection

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -18,9 +18,6 @@ analysis_settings:
     kmeraligner:
         yaml : ../envs/kmeraligner.yaml
 
-    resistance_gene_detection:
-        yaml : ../envs/resistence_gene_detection.yaml
-
     emm_typing:
         yaml : ../envs/emm_typing.yaml
         
@@ -43,9 +40,6 @@ analysis_settings:
         
     serotypefinder:
         yaml : ../envs/serotypefinder.yaml
-
-    # kmerfinder:
-    #     yaml : ../envs/kmerfinder.yaml
 
     cgMLSTFinder:
         yaml : ../envs/cgMLSTfinder.yaml

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -72,14 +72,6 @@ rule all:
             out=OUT_FOLDER
         ),       
         expand(
-            "{out}/{sample}/blast/", 
-            sample=[
-                s for s in SAMPLES 
-                if species_configs[sample_to_organism[s]]["analyses_to_run"]["resistance_gene_detection"]["status"] is True
-            ],
-            out=OUT_FOLDER
-        ),
-        expand(
             "{out}/{sample}/assembly_lineage/", 
             sample=[
                 s for s in SAMPLES 
@@ -143,14 +135,6 @@ rule all:
             ],
             out=OUT_FOLDER
         ),
-        # expand(
-        #     "{out}/{sample}/kmerfinder/", 
-        #     sample=[
-        #         s for s in SAMPLES 
-        #         if species_configs[sample_to_organism[s]]["analyses_to_run"]["kmerfinder"]["status"] is True
-        #     ],
-        #     out=OUT_FOLDER
-        # ),
         expand(
             "{out}/{sample}/cgmlstfinder/", 
             sample=[

--- a/workflow/configs_species/E.coli.yaml
+++ b/workflow/configs_species/E.coli.yaml
@@ -27,14 +27,6 @@ analyses_to_run:
         deltafilterargs : "\"-q -r -o 100\""
         reference_fasta_file: resources/lineage_determination/MGAS5005.fasta
         lineage_variant_file: resources/lineage_determination/Spyogenes_LOCs.tsv
-
-    resistance_gene_detection: 
-        status : False
-        Title: Presence of resistance gens tetM, ermA and ermB
-        query_fasta_resistance_gene_detection: resources/AMR/AMR_genes.fasta  # Fasta file with AMR genes
-        query_fasta_virulence_gene_detection: resources/virulence_factors/VFDB_genes.fasta  # Fasta file with virulence genes
-        pident_threshold: 80
-        cov_threshold: 80
         
     virulence_gene_detection: 
         status : False
@@ -80,12 +72,6 @@ analyses_to_run:
         threshold : 0.90
         coverage : 0.60
         database: resources/chtyper_db/  # CHTyper database
-    
-    # kmerfinder : 
-    #     status : False
-    #     Title : Kmerfinder
-    #     taxa : resources/kmerfinder_db/kmerfinder_db_old/bacteria.tax
-    #     database: resources/kmerfinder_db/kmerfinder_db_old/bacteria.ATG  # KmerFinder database for bacterial genomes
 
     cgMLSTFinder : 
         status : False

--- a/workflow/rules/finders.smk
+++ b/workflow/rules/finders.smk
@@ -145,34 +145,6 @@ rule serotypefinder:
         serotypefinder -i {input.R1} {input.R2} -o {output} -p {params.db_path} 
         """
 
-# Rule: kmerfinder
-# Identifies microbial species or strain using k-mer-based alignment.
-# rule kmerfinder:
-#     input:
-#         R1 = lambda wildcards: sample_to_illumina[wildcards.sample][0],
-#         R2 = lambda wildcards: sample_to_illumina[wildcards.sample][1]
-#     params:
-#         # Path to the kmerfinder database, KMA aligner, and taxa file.
-#         db_path = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["kmerfinder"]["database"],
-#         taxa = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["kmerfinder"]["taxa"]
-#     output:
-#         directory("{out}/{sample}/kmerfinder/")
-#     conda:
-#         config["analysis_settings"]["kmerfinder"]["yaml"]
-#     shell:
-#         """
-#         # Check if the output directory exists, and skip if it does.
-#         if [ -d {output} ]; 
-#             then
-#                 echo "Directory {output} exists, skipping."
-#                 exit 1
-#             else
-#                 mkdir {output}
-#         fi 
-#         # Run kmerfinder.py with the specified parameters and inputs.
-#         kmerfinder.py  -i {input.R1} {input.R2} -o {output} -db {params.db_path} -tax {params.taxa}
-#         """
-
 # Rule: cgMLSTFinder
 # Runs cgMLSTFinder for comparative genomic typing.
 rule cgMLSTFinder:

--- a/workflow/rules/others.smk
+++ b/workflow/rules/others.smk
@@ -32,42 +32,6 @@ rule kmeraligner:
         """
 
 
-
-# Rule for resistance gene detection using BLAST
-rule resistance_gene_detection:
-    input:
-        # Input: AMR gene database file and assembly file for the sample
-        amr_genes = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["resistance_gene_detection"]["query_fasta_resistance_gene_detection"],
-        assembly = lambda wildcards: sample_to_assembly_file[wildcards.sample]  # Use wildcards to get the sample's assembly file
-    params:
-        # Parameters for BLAST, including identity and coverage thresholds
-        id_per = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["resistance_gene_detection"]["pident_threshold"],
-        cov_per = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["resistance_gene_detection"]["cov_threshold"],
-    output:
-        # Output is a directory to store BLAST results for the sample
-        directory("{out}/{sample}/blast/")
-    conda:
-        config["analysis_settings"]["resistance_gene_detection"]["yaml"]
-    shell:
-        """
-        # Check if the output directory exists, skip execution if it does
-        if [ -d {output} ]; 
-            then
-                echo "Directory {output} exists,skipping."
-                exit 1  # Exit without running if the directory exists
-            else
-                mkdir {output}  # Create the directory if it doesn't exist
-        fi
-
-        # Run BLAST with specified input and output options
-        blastn -query {input.amr_genes} \
-               -subject {input.assembly} \
-               -out {output}/blast_output.tsv \
-               -outfmt '6 qseqid sseqid pident length qlen qstart qend sstart send sseq evalue bitscore' \
-               -perc_identity {params.id_per} \
-               -qcov_hsp_perc {params.cov_per}
-        """
-
 # Rule for emm typing using BLAST
 rule emm_typing:
     input:
@@ -81,7 +45,7 @@ rule emm_typing:
         # Output is a directory to store emm typing results for the sample
         directory("{out}/{sample}/emm_typing/")
     conda:
-        config["analysis_settings"]["resistance_gene_detection"]["yaml"]
+        config["analysis_settings"]["emm_typing"]["yaml"]
     shell:
         """
         # Check if the output directory exists, skip execution if it does


### PR DESCRIPTION
Some tools are not used in practise any more and are thus redundant. Objects related to KMERFinder & Resistance Genes detection rules have been purged.