### PR TITLE
Added temporary Automatic DB handler for Ecoli kmerAligner and polished kmeraligner rule

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -18,6 +18,7 @@ analysis_settings:
 
     kmeraligner:
         yaml : ../envs/kmeraligner.yaml
+        database: kmeraligner
 
     emm_typing:
         yaml : ../envs/emm_typing.yaml

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -53,7 +53,7 @@ database_path = config['input_manager']['database_path']
 rule all:
     input:
         expand(
-            "%s/{sample}/kma/" %OUT_FOLDER, 
+            "%s/{sample}/kmeraligner/" %OUT_FOLDER, 
             sample=[
                 s for s in SAMPLES 
                 if species_configs[sample_to_organism[s]]["analyses_to_run"]["kmeraligner"]["status"] is True

--- a/workflow/envs/kmeraligner.yaml
+++ b/workflow/envs/kmeraligner.yaml
@@ -4,5 +4,5 @@ channels:
 dependencies:
   - python=3.9
   - kma
-  - wget
+  - curl
  

--- a/workflow/envs/kmeraligner.yaml
+++ b/workflow/envs/kmeraligner.yaml
@@ -3,5 +3,6 @@ channels:
   - bioconda
 dependencies:
   - python=3.9
-  - kma 
+  - kma
+  - wget
  

--- a/workflow/rules/db_setups.smk
+++ b/workflow/rules/db_setups.smk
@@ -150,3 +150,34 @@ rule setup_AMRFinder:
         echo "Executing command:\n$cmd\n" >> {log.stdout} 2>&1
         eval $cmd >> {log.stdout} 2>&1
         """
+
+rule setup_EcoliKmerAligner:
+    conda:
+        config["analysis_settings"]["kmeraligner"]["yaml"]
+    params:
+        db_prefix = 'ecoligenes'
+    output:
+        database = directory(f'{database_path}/{config["analysis_settings"]["kmeraligner"]["database"]}')
+    log:
+        stdout = f'Logs/Databases/setup_EcoliKmerAligner.log'
+    message:
+        "[setup_EcoliKmerAligner]: Setting up EcoliKmerAligner"
+    shell:
+        """
+        cmd="wget https://raw.githubusercontent.com/ssi-dk/ecoli_fbi/refs/heads/main/db/ecoligenes/ecoligenes.fsa -P {output.database}"
+
+        echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
+        eval $cmd >> {log.stdout} 2>&1
+
+        fasta={output.database}/ecoligenes.fsa
+
+        idx_prefix={output.database}/{params.db_prefix}
+        cmd="kma index -i $fasta -o $idx_prefix"
+
+        echo "Executing command:\n$cmd\n" >> {log.stdout} 2>&1
+        eval $cmd >> {log.stdout} 2>&1
+
+        if [ -z $idx_prefix.comb.b ]; then
+            echo '[virulencefinder_db]: ERROR - $idx_prefix.comb.b was not created during KMA indexing. This likely means that the virulencefinder_db has changed. Post this message on our Github repository!' 2>&1 >> {log.stdout}
+        fi
+        """

--- a/workflow/rules/db_setups.smk
+++ b/workflow/rules/db_setups.smk
@@ -164,7 +164,8 @@ rule setup_EcoliKmerAligner:
         "[setup_EcoliKmerAligner]: Setting up EcoliKmerAligner"
     shell:
         """
-        cmd="wget https://raw.githubusercontent.com/ssi-dk/ecoli_fbi/refs/heads/main/db/ecoligenes/ecoligenes.fsa -P {output.database}"
+        mkdir -p {output.database}
+        cmd="curl https://raw.githubusercontent.com/ssi-dk/ecoli_fbi/refs/heads/main/db/ecoligenes/ecoligenes.fsa -o {output.database}/{params.db_prefix}.fsa"
 
         echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
         eval $cmd >> {log.stdout} 2>&1


### PR DESCRIPTION
Current Ecoli kmeraligner database is hosted as part of a repo, to simplify, only the db file is downloaded using wget (thus wget has been added to envs/kmeraligner.yaml). The repo is prob not stable (not maintained) and thus this fix should be seen as a temporary addition to #7. To make rule comply with latest Logging and Messaging setup, the kmeraligner rule have recieved a polishing.