### PR TITLE
Added update rule for MLST

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -4,6 +4,7 @@ import os
 import yaml
 from scripts import convert_external_genome
 import warnings
+import math
 
 configfile: "config/config.yaml"
 

--- a/workflow/rules/characterizers.smk
+++ b/workflow/rules/characterizers.smk
@@ -3,6 +3,7 @@
 rule MLST:
     input:
         assembly = lambda wildcards: sample_to_assembly_file[wildcards.sample],
+        datefile = rules.update_MLST.output.datefile
     output:
         # mlst_file = "%s/{sample}/MLST/{sample}.tsv" %OUT_FOLDER
         directory("%s/{sample}/MLST" %OUT_FOLDER)

--- a/workflow/rules/db_setups.smk
+++ b/workflow/rules/db_setups.smk
@@ -189,7 +189,7 @@ rule update_MLST:
     log:
         stdout = f'Logs/Databases/update_MLST.log'
     message:
-        "[setup_AMRFinder]: Updating MLST databases."
+        "[setup_AMRFinder]: Updating MLST databases - This WILL take a long time -> Follow the update_MLST.log for more information."
     shell:
         """
         DIR=$(which mlst)

--- a/workflow/rules/db_setups.smk
+++ b/workflow/rules/db_setups.smk
@@ -182,3 +182,20 @@ rule setup_EcoliKmerAligner:
             echo '[virulencefinder_db]: ERROR - $idx_prefix.comb.b was not created during KMA indexing. This likely means that the virulencefinder_db has changed. Post this message on our Github repository!' 2>&1 >> {log.stdout}
         fi
         """
+
+rule update_MLST:
+    conda:
+        config["analysis_settings"]["mlst"]["yaml"]
+    log:
+        stdout = f'Logs/Databases/update_MLST.log'
+    message:
+        "[setup_AMRFinder]: Updating MLST databases."
+    shell:
+        """
+        DIR=$(which mlst)
+        MLSTDIR="$DIR/../../db/pubmlst"
+
+
+        mlst-download_pub_mlst -d $MLSTDIR > {log.stdout} 2>&1
+        mlst-make_blast_db >> {log.stdout} 2>&1
+        """

--- a/workflow/rules/db_setups.smk
+++ b/workflow/rules/db_setups.smk
@@ -186,16 +186,22 @@ rule setup_EcoliKmerAligner:
 rule update_MLST:
     conda:
         config["analysis_settings"]["mlst"]["yaml"]
+    output:
+        datefile = f'{database_path}/mlst/creation.date'
     log:
         stdout = f'Logs/Databases/update_MLST.log'
     message:
-        "[setup_AMRFinder]: Updating MLST databases - This WILL take a long time -> Follow the update_MLST.log for more information."
+        "[update_MLST]: Updating MLST databases."
+    threads:
+        max(math.floor(workflow.cores // 2), 6)
     shell:
         """
         DIR=$(which mlst)
         MLSTDIR="$DIR/../../db/pubmlst"
 
 
-        mlst-download_pub_mlst -d $MLSTDIR > {log.stdout} 2>&1
+        mlst-download_pub_mlst -d $MLSTDIR -j {threads} > {log.stdout} 2>&1
         mlst-make_blast_db >> {log.stdout} 2>&1
+
+        date -I > {output.datefile}
         """

--- a/workflow/rules/db_setups.smk
+++ b/workflow/rules/db_setups.smk
@@ -1,3 +1,4 @@
+
 rule setup_PlasmidFinder:
     conda:
         config["analysis_settings"]["plasmidfinder"]["yaml"]
@@ -192,16 +193,12 @@ rule update_MLST:
         stdout = f'Logs/Databases/update_MLST.log'
     message:
         "[update_MLST]: Updating MLST databases."
-    threads:
-        max(math.floor(workflow.cores // 2), 6)
     shell:
         """
         DIR=$(which mlst)
         MLSTDIR="$DIR/../../db/pubmlst"
 
 
-        mlst-download_pub_mlst -d $MLSTDIR -j {threads} > {log.stdout} 2>&1
-        mlst-make_blast_db >> {log.stdout} 2>&1
-
-        date -I > {output.datefile}
+        mlst-download_pub_mlst -d $MLSTDIR  > {log.stdout} 2>&1
+        mlst-make_blast_db >> {log.stdout} 2>&1 && date -I > {output.datefile}
         """


### PR DESCRIPTION
Due to some limitations in MLST setup, database updates can't be tied to snakemake rules output, and thus made as a dependency of the MLST execution. To manually force update (TAKES TIME!) run