### PR TITLE
Cleaning database logic and general cleaning

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -139,7 +139,7 @@ rule all:
             ]
         ),
         expand(
-            "%s/{sample}/AMRFinder/AMR_{assembler}_{sample}.tsv" % OUT_FOLDER,
+            "%s/{sample}/AMRFinder/{assembler}.tsv" % OUT_FOLDER,
             sample=[
                 s for s in SAMPLES for assembler in ASM_TO_REPEAT_IDENTIFICATION
                 if "amrfinder" in species_configs[sample_to_organism[s]]["analyses_to_run"]
@@ -151,6 +151,13 @@ rule all:
                 and assembler in species_configs[sample_to_organism[s]]["analyses_to_run"]
             ]
         ),
+        expand(
+           "%s/{sample}/MLST/{sample}.tsv" % OUT_FOLDER,
+           sample=[
+               s for s in SAMPLES 
+               if "mlst" in species_configs[sample_to_organism[s]]["analyses_to_run"]
+           ]
+      ),
         expand(
             "%s/{sample}/Repeat_identifier/{assembler}_{sample}_repeat.tsv" % OUT_FOLDER,
             sample=[
@@ -163,37 +170,6 @@ rule all:
                 if "Repeat_identifier" in species_configs[sample_to_organism[s]]["analyses_to_run"]
                 and assembler in species_configs[sample_to_organism[s]]["analyses_to_run"]
             ]
-        ),
-        expand(
-            "%s/{sample}/FilteredBAM/{sample}.{tool}.filtered.sorted.bam.bai" % OUT_FOLDER,
-            sample=[
-                s for s in SAMPLES
-                for tool in TOOLS_WITH_SAM_OUTPUT
-                if tool in species_configs[sample_to_organism[s]]["analyses_to_run"]
-                and "samtools_idx" in species_configs[sample_to_organism[s]]["analyses_to_run"]
-            ],
-            tool=TOOLS_WITH_SAM_OUTPUT
-        ),
-        expand(
-            "%s/{sample}/GenotypeCalls/{sample}.{tool}.{tag}.bcf.csi" % OUT_FOLDER,
-            sample=[
-                s for s in SAMPLES
-                for tool in TOOLS_WITH_SAM_OUTPUT
-                if tool in species_configs[sample_to_organism[s]]["analyses_to_run"]
-                and "bcftools_index" in species_configs[sample_to_organism[s]]["analyses_to_run"]
-            ],
-            tool=TOOLS_WITH_SAM_OUTPUT,
-            tag=["calls", "indels"]
-        ),
-        expand(
-            "%s/{sample}/GenotypeCalls/{sample}.{tool}.calls.bcf" % OUT_FOLDER,
-            sample=[
-                s for s in SAMPLES
-                for tool in TOOLS_WITH_SAM_OUTPUT
-                if tool in species_configs[sample_to_organism[s]]["analyses_to_run"]
-                and "bcftools_call" in species_configs[sample_to_organism[s]]["analyses_to_run"]
-            ],
-            tool=TOOLS_WITH_SAM_OUTPUT
         ),
         expand(
             "%s/{sample}/GenotypeCalls/{sample}.{tool}.indels.bcf" % OUT_FOLDER,
@@ -218,8 +194,8 @@ rule all:
 
 include : "rules/db_setups.smk"
 include : "rules/finders.smk"
-include : "rules/characterizers.smk"
 include : "rules/others.smk"
+include : "rules/characterizers.smk"
 
 #        expand(
 #           "%s/{sample}/emm_typing/" % OUT_FOLDER,
@@ -235,10 +211,3 @@ include : "rules/others.smk"
 #                if "assembly_lineage_determination" in species_configs[sample_to_organism[s]]["analyses_to_run"]
 #            ]
 #        ),
-#        expand(
-#            "%s/{sample}/MLST" % OUT_FOLDER,
-#            sample=[
-#                s for s in SAMPLES
-#                if "mlst" in species_configs[sample_to_organism[s]]["analyses_to_run"]
-#            ]
-#       ),

--- a/workflow/configs_species/C.diff.yaml
+++ b/workflow/configs_species/C.diff.yaml
@@ -77,7 +77,10 @@ analyses_to_run:
     amrfinder:
         Title : NCBI resistance gene finder
         organism: --organism Clostridioides_difficile # Leave blank or insert --organism alongside one of the supported organisms, listed here: https://github.com/evolarjun/amr/wiki/Curated-organisms
-    
+
+    mlst:
+       Title : MLST by Torsten Seeman
+
     spades:
         Title : spades assembly
 
@@ -155,8 +158,7 @@ analyses_to_run:
 #        reference_fasta_file: resources/lineage_determination/MGAS5005.fasta
 #        lineage_variant_file: resources/lineage_determination/Spyogenes_LOCs.tsv
 #        
-#    mlst:
-#        Title : MLST by Torsten Seeman
+
 #    LRE-finder: 
 #        Title : LRE-Finder
 #        min_consensus_ID : 80

--- a/workflow/configs_species/E.coli.yaml
+++ b/workflow/configs_species/E.coli.yaml
@@ -84,6 +84,9 @@ analyses_to_run:
         organism: --organism Escherichia # Leave blank or insert --organism alongside one of the supported organisms, listed here: https://github.com/evolarjun/amr/wiki/Curated-organisms
         wrangler: workflow/scripts/AMR_wrangler.py
 
+    mlst:
+       Title : MLST by Torsten Seeman
+
     spades:
         Title : spades assembly
 
@@ -105,8 +108,6 @@ analyses_to_run:
 #        reference_fasta_file: resources/lineage_determination/MGAS5005.fasta
 #        lineage_variant_file: resources/lineage_determination/Spyogenes_LOCs.tsv
 #        
-#    mlst:
-#        Title : MLST by Torsten Seeman
 #
 #    LRE-finder: 
 #        Title : LRE-Finder

--- a/workflow/envs/amrfinder.yaml
+++ b/workflow/envs/amrfinder.yaml
@@ -4,3 +4,4 @@ channels:
   - bioconda
 dependencies:
   - ncbi-amrfinderplus
+  - curl

--- a/workflow/rules/characterizers.smk
+++ b/workflow/rules/characterizers.smk
@@ -2,11 +2,11 @@
 # Runs Multi Locus Sequence Type to determine the ST profile of isolate
 rule MLST:
     input:
-        assembly = lambda wildcards: sample_to_assembly_file[wildcards.sample],
+        assembly = rules.spades_assembly.output.contigs,
         datefile = rules.update_MLST.output.datefile
     output:
         # mlst_file = "%s/{sample}/MLST/{sample}.tsv" %OUT_FOLDER
-        directory("%s/{sample}/MLST" %OUT_FOLDER)
+        directory("%s/{sample}/MLST/{sample}.tsv" %OUT_FOLDER)
     conda:
         config["analysis_settings"]["mlst"]["yaml"]
     log:

--- a/workflow/rules/db_setups.smk
+++ b/workflow/rules/db_setups.smk
@@ -3,52 +3,55 @@ import re
 def db_flat_to_path(name):
     # Replace the first underscore after _db with a slash
     return re.sub(r'(_db)_(?=[^_]+$)', r'\1/', name)
-    
+
+
 rule kma_index_directory:
-    output:
-        flag = "Logs/Databases/{db_name_flat}.kma_index.done"
     input:
-        fasta_dir = lambda wc: "resources/%s" % db_flat_to_path(wc.db_name_flat)
+        fasta_dir = lambda wc: "%s/%s" %(database_path, db_flat_to_path(wc.db_name_flat))
+    output:
+        flag = "%s/{db_name_flat}.kma_index.done" %database_path
     conda:
         config["analysis_settings"]["KMA"]["yaml"]
     message:
         "[kma_index_directory]: Indexing all FASTA in {input.fasta_dir}"
     shell:
-        r"""
+        """
         mkdir -p {input.fasta_dir}
 
-        for fasta in $(find {input.fasta_dir} -maxdepth 1 -type f \( -name "*.fa" -o -name "*.fsa" -o -name "*.fasta" \)); do
+        for fasta in $(find {input.fasta_dir} -maxdepth 1 -type f  -name "*.f*a*"); do
+            echo $fasta
             prefix="${{fasta%.*}}"
             echo "Indexing $fasta -> $prefix"
             kma index -i "$fasta" -o "$prefix"
         done
 
-        touch {output.flag}
+        date -I >> {output.flag}
         """
 
 rule samtools_faidx_directory:
-    output:
-        flag = "Logs/Databases/{db_name_flat}.fa_idx.done"
     input:
-        fasta_dir = lambda wc: "resources/%s" % db_flat_to_path(wc.db_name_flat)
+        fasta_dir = lambda wc: "%s/%s" %(database_path, db_flat_to_path(wc.db_name_flat))
+    output:
+        flag = "%s/{db_name_flat}.fa_idx.done" %database_path
     conda:
         config["analysis_settings"]["htslib"]["yaml"]
     message:
         "[samtools_faidx_directory]: Indexing all FASTA in {input.fasta_dir}"
     shell:
-        r"""
+        """
         mkdir -p {input.fasta_dir}
-        touch {output.flag}
     
-        for fasta in $(find {input.fasta_dir} -maxdepth 1 -type f \( -name "*.fa" -o -name "*.fsa" -o -name "*.fasta" \)); do
+        for fasta in $(find {input.fasta_dir} -maxdepth 1 -type f  -name "*.f*a*"); do
             prefix="${{fasta%.*}}"
             echo "Indexing $fasta -> $prefix"
             cmd="samtools faidx $fasta"
             echo "Executing command:\n$cmd\n" >> {output.flag} 
             eval $cmd >> {output.flag} 2>&1
-            date -I >> {output.flag}
-        done    
+        done
+
+        date -I >> {output.flag}
         """
+
 
 rule setup_Ecoli_alignment_db:
     conda:
@@ -72,6 +75,7 @@ rule setup_Ecoli_alignment_db:
         date -I > {output.database}/creation.date
         """
 
+
 rule setup_CdiffToxin:
     conda:
         config["analysis_settings"]["Clostridioides_difficile_db"]["yaml"]
@@ -85,7 +89,7 @@ rule setup_CdiffToxin:
     message:
         "[setup_CdiffToxin]: Setting up C. difficile toxin database"
     shell:
-        r"""
+        """
         set -euo pipefail
         mkdir -p {output.database}
         > {output.database}/{params.db_toxin}.txt
@@ -136,7 +140,7 @@ rule setup_CdiffTRST:
     message:
         "[setup_CdiffTRST]: Downloading TRST repeat sequences and types"
     shell:
-        r"""
+        """
         set -euo pipefail
         mkdir -p {output.database}
 
@@ -161,7 +165,7 @@ rule setup_PlasmidFinder:
     conda:
         config["analysis_settings"]["plasmidfinder"]["yaml"]
     output: 
-        database = directory("%s/%s" % (database_path, config["analysis_settings"]["plasmidfinder"]["database"]))
+        database = directory("%s/%s" %(database_path, config["analysis_settings"]["plasmidfinder"]["database"]))
     log:
         stdout = 'Logs/Databases/setup_PlasmidFinder.log'
     message:
@@ -169,6 +173,18 @@ rule setup_PlasmidFinder:
     shell:
         """
         git clone https://bitbucket.org/genomicepidemiology/plasmidfinder_db.git {output.database} > {log.stdout} 2>&1
+
+        for fasta in $(find {output.database} -iname '*.fsa'); do
+            idx_prefix={output.database}/$(basename $fasta .fsa)
+            cmd="kma index -i $fasta -o $idx_prefix"
+            
+            echo "Executing command:\n$cmd\n" >> {log.stdout} 2>&1
+            eval $cmd >> {log.stdout} 2>&1
+            
+            if [ -z $idx_prefix.comb.b ]; then
+                echo '[plasmidfinder_db]: ERROR - $idx_prefix.comb.b was not created during KMA indexing. This likely means that the plasmidfinder_db has changed. Post this message on our Github repository!' 2>&1 >> {log.stdout}
+            fi
+        done
         
         date -I > {output.database}/creation.date
         """
@@ -187,6 +203,18 @@ rule setup_ResFinder:
         """
         git clone https://bitbucket.org/genomicepidemiology/resfinder_db.git {output.database} > {log.stdout} 2>&1
         
+        for fasta in $(find {output.database} -iname '*.fsa'); do
+            idx_prefix={output.database}/$(basename $fasta .fsa)
+            cmd="kma index -i $fasta -o $idx_prefix"
+
+            echo "Executing command:\n$cmd\n" >> {log.stdout} 2>&1
+            eval $cmd >> {log.stdout} 2>&1
+            
+            if [ -z $idx_prefix.comb.b ]; then
+                echo '[resfinder_db]: ERROR - $idx_prefix.comb.b was not created during KMA indexing. This likely means that the resfinder_db has changed. Post this message on our Github repository!' 2>&1 >> {log.stdout}
+            fi
+        done
+        
         date -I > {output.database}/creation.date
         """
 
@@ -204,6 +232,19 @@ rule setup_PointFinder:
         """
         git clone https://bitbucket.org/genomicepidemiology/pointfinder_db.git {output.database} > {log.stdout} 2>&1
 
+        for fasta in $(find {output.database} -iname '*.fsa'); do
+            idx_prefix={output.database}/$(basename $fasta .fsa)
+            cmd="kma index -i $fasta -o $idx_prefix"
+            
+            echo "Executing command:\n$cmd\n" >> {log.stdout} 2>&1
+            eval $cmd >> {log.stdout} 2>&1
+
+            
+            if [ -z $idx_prefix.comb.b ]; then
+                echo '[pointfinder_db]: ERROR - $idx_prefix.comb.b was not created during KMA indexing. This likely means that the pointfinder_db has changed. Post this message on our Github repository!' 2>&1 >> {log.stdout}
+            fi
+        done
+        
         date -I > {output.database}/creation.date
         """
 
@@ -220,6 +261,18 @@ rule setup_DisinFinder:
         """
         git clone https://bitbucket.org/genomicepidemiology/disinfinder_db.git {output.database} > {log.stdout} 2>&1
 
+        for fasta in $(find {output.database} -iname '*.fsa'); do
+            idx_prefix={output.database}/$(basename $fasta .fsa)
+            cmd="kma index -i $fasta -o $idx_prefix"
+            
+            echo "Executing command:\n$cmd\n" >> {log.stdout} 2>&1
+            eval $cmd >> {log.stdout} 2>&1
+            
+            if [ -z $idx_prefix.comb.b ]; then
+                echo '[disinfinder_db]: ERROR - $idx_prefix.comb.b was not created during KMA indexing. This likely means that the disinfinder_db has changed. Post this message on our Github repository!' 2>&1 >> {log.stdout}
+            fi
+        done
+        
         date -I > {output.database}/creation.date
         """
 
@@ -237,6 +290,18 @@ rule setup_VirulenceFinder:
         """
         git clone https://bitbucket.org/genomicepidemiology/virulencefinder_db.git {output.database} > {log.stdout} 2>&1
        
+        for fasta in $(find {output.database} -iname '*.fsa'); do
+            idx_prefix={output.database}/$(basename $fasta .fsa)
+            cmd="kma index -i $fasta -o $idx_prefix"
+            
+            echo "Executing command:\n$cmd\n" >> {log.stdout} 2>&1
+            eval $cmd >> {log.stdout} 2>&1
+            
+            if [ -z $idx_prefix.comb.b ]; then
+                echo '[virulencefinder_db]: ERROR - $idx_prefix.comb.b was not created during KMA indexing. This likely means that the virulencefinder_db has changed. Post this message on our Github repository!' 2>&1 >> {log.stdout}
+            fi
+        done
+        
         date -I > {output.database}/creation.date
         """
 
@@ -253,6 +318,18 @@ rule setup_SerotypeFinder:
     shell:
         """
         git clone https://bitbucket.org/genomicepidemiology/serotypefinder_db.git {output.database} > {log.stdout} 2>&1
+
+        for fasta in $(find {output.database} -iname '*.fsa'); do
+            idx_prefix={output.database}/$(basename $fasta .fsa)
+            cmd="kma index -i $fasta -o $idx_prefix"
+            
+            echo "Executing command:\n$cmd\n" >> {log.stdout} 2>&1
+            eval $cmd >> {log.stdout} 2>&1
+            
+            if [ -z $idx_prefix.comb.b ]; then
+                echo '[serotypefinder_db]: ERROR - $idx_prefix.comb.b was not created during KMA indexing. This likely means that the serotypefinder_db has changed. Post this message on our Github repository!' 2>&1 >> {log.stdout}
+            fi
+        done
 
         date -I > {output.database}/creation.date
         """

--- a/workflow/rules/finders.smk
+++ b/workflow/rules/finders.smk
@@ -7,11 +7,10 @@ rule PlasmidFinder:
         # Input paired-end Illumina reads.
         R1 = lambda wildcards: sample_to_illumina[wildcards.sample][0],
         R2 = lambda wildcards: sample_to_illumina[wildcards.sample][1],
-        db_index = lambda wc: f"Logs/Databases/{species_configs[sample_to_organism[wc.sample]]['alignment_database']['plasmidfinder']['kma_index_flag']}.kma_index.done",
-        db_dir = lambda wc: f"{getattr(rules, species_configs[sample_to_organism[wc.sample]]['alignment_database']['plasmidfinder']['db']).output.database}",
+        database = rules.setup_PlasmidFinder.output.database
     output:
         # Output directory for plasmidfinder results.
-        out_dir = directory(f"{OUT_FOLDER}" + "/{sample}/PlasmidFinder")
+        out_dir = directory("%s/{sample}/PlasmidFinder" %OUT_FOLDER)
     conda:
         config["analysis_settings"]["plasmidfinder"]["yaml"]
     log:
@@ -22,7 +21,7 @@ rule PlasmidFinder:
         """
         mkdir -p {output.out_dir}
 
-        cmd="plasmidfinder.py -i {input.R1} {input.R2} -o {output.out_dir} -p {input.db_dir} -x"
+        cmd="plasmidfinder.py -i {input.R1} {input.R2} -o {output.out_dir} -p {input.database} -x"
 
         echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
         eval $cmd >> {log.stdout} 2>&1
@@ -34,14 +33,11 @@ rule ResFinder:
     input:
         R1 = lambda wildcards: sample_to_illumina[wildcards.sample][0],
         R2 = lambda wildcards: sample_to_illumina[wildcards.sample][1],
-        res_db_index = lambda wc: f"Logs/Databases/{species_configs[sample_to_organism[wc.sample]]['alignment_database']['resfinder']['kma_index_flag']}.kma_index.done",
-        res_db_dir = lambda wc: f"{getattr(rules, species_configs[sample_to_organism[wc.sample]]['alignment_database']['resfinder']['db']).output.database}",
-        point_db_index = lambda wc: f"Logs/Databases/{species_configs[sample_to_organism[wc.sample]]['alignment_database']['pointfinder']['kma_index_flag']}.kma_index.done",
-        point_db_dir = lambda wc: f"{getattr(rules, species_configs[sample_to_organism[wc.sample]]['alignment_database']['pointfinder']['db']).output.database}",
-        disin_db_index = lambda wc: f"Logs/Databases/{species_configs[sample_to_organism[wc.sample]]['alignment_database']['disinfinder']['kma_index_flag']}.kma_index.done",
-        disin_db_dir = lambda wc: f"{getattr(rules, species_configs[sample_to_organism[wc.sample]]['alignment_database']['disinfinder']['db']).output.database}",
+        res_database = rules.setup_ResFinder.output.database,
+        #point_database = rules.setup_PointFinder.output.database, #Pointfinder requires `species` definition
+        disin_database = rules.setup_DisinFinder.output.database
     output:
-        out_dir = directory(f"{OUT_FOLDER}" + "/{sample}/ResFinder")
+        out_dir = directory("%s/{sample}/ResFinder" %OUT_FOLDER)
     conda:
         config["analysis_settings"]["resfinder"]["yaml"]
     log:
@@ -52,7 +48,7 @@ rule ResFinder:
         """
         mkdir -p {output.out_dir}
 
-        cmd="run_resfinder.py -ifq {input.R1} {input.R2} -o {output} -db_res {input.res_db_dir} -db_res_kma {input.res_db_dir} -db_disinf {input.disin_db_dir} -db_point {input.point_db_dir} -acq"
+        cmd="run_resfinder.py -ifq {input.R1} {input.R2} -o {output} --acquired -db_res {input.res_database} --disinfectant -db_disinf {input.disin_database}"
  
         echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
         eval $cmd >> {log.stdout} 2>&1
@@ -64,10 +60,9 @@ rule VirulenceFinder:
     input:
         R1 = lambda wildcards: sample_to_illumina[wildcards.sample][0],
         R2 = lambda wildcards: sample_to_illumina[wildcards.sample][1],
-        vir_db_index = lambda wc: f"Logs/Databases/{species_configs[sample_to_organism[wc.sample]]['alignment_database']['virulencefinder']['kma_index_flag']}.kma_index.done",
-        vir_db_dir = lambda wc: f"{getattr(rules, species_configs[sample_to_organism[wc.sample]]['alignment_database']['virulencefinder']['db']).output.database}",
+        database = rules.setup_VirulenceFinder.output.database
     output:
-        out_dir = directory(f"{OUT_FOLDER}" + "/{sample}/VirulenceFinder")
+        out_dir = directory("%s/{sample}/VirulenceFinder" %OUT_FOLDER)
     conda:
         config["analysis_settings"]["virulencefinder"]["yaml"]
     log:
@@ -78,7 +73,7 @@ rule VirulenceFinder:
         """
         mkdir -p {output.out_dir}
 
-        cmd="virulencefinder.py -i {input.R1} {input.R2} -o {output.out_dir} -p {input.vir_db_dir}"
+        cmd="virulencefinder.py -i {input.R1} {input.R2} -o {output.out_dir} -p {input.database}"
 
         echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
         eval $cmd >> {log.stdout} 2>&1
@@ -91,11 +86,9 @@ rule serotypefinder:
     input:
         R1 = lambda wildcards: sample_to_illumina[wildcards.sample][0],
         R2 = lambda wildcards: sample_to_illumina[wildcards.sample][1],
-        ser_db_index = lambda wc: f"Logs/Databases/{species_configs[sample_to_organism[wc.sample]]['alignment_database']['serotypefinder']['kma_index_flag']}.kma_index.done",
-        ser_db_dir = lambda wc: f"{getattr(rules, species_configs[sample_to_organism[wc.sample]]['alignment_database']['serotypefinder']['db']).output.database}",
         database = rules.setup_SerotypeFinder.output.database
     output:
-        out_dir = directory(f"{OUT_FOLDER}" + "/{sample}/SerotypeFinder")
+        out_dir = directory("%s/{sample}/SerotypeFinder" %OUT_FOLDER)
     conda:
         config["analysis_settings"]["serotypefinder"]["yaml"]
     log:
@@ -106,7 +99,7 @@ rule serotypefinder:
         """
         mkdir -p {output.out_dir}
 
-        cmd="serotypefinder -i {input.R1} {input.R2} -o {output.out_dir} -p {input.ser_db_dir} -x"
+        cmd="serotypefinder -i {input.R1} {input.R2} -o {output.out_dir} -p {input.database} -x"
 
         echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
         eval $cmd >> {log.stdout} 2>&1
@@ -130,11 +123,11 @@ rule AMRFinder:
         # Point mutation
         organism = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["amrfinder"]["organism"]
     output:
-        result = "%s/{sample}/AMRFinder/AMR_{assembler}_{sample}.tsv" %OUT_FOLDER
+        result = "%s/{sample}/AMRFinder/{assembler}.tsv" %OUT_FOLDER
     conda:
         config["analysis_settings"]["amrfinder"]["yaml"]
     log:
-        stdout = 'Logs/{sample}/AMRFinder/AMRFinder_{assembler}.log'
+        stdout = 'Logs/{sample}/AMRFinder_{assembler}.log'
     message:
         "[AMRFinder]: Running AMRFinderFinder for {wildcards.sample} using ({wildcards.assembler}) contigs"
     shell:
@@ -163,7 +156,7 @@ rule LREFinder:
     conda:
         config["analysis_settings"]["LRE-finder"]["yaml"]
     output:
-        directory(f"{OUT_FOLDER}/{{sample}}/lre-finder/")
+        directory("%s/{sample}/lre-finder/" %OUT_FOLDER)
     shell:
         """
         # Check if the output directory exists, and skip if it does.

--- a/workflow/rules/others.smk
+++ b/workflow/rules/others.smk
@@ -6,8 +6,8 @@ rule kmeraligner:
     input:
         R1 = lambda wc: sample_to_illumina[wc.sample][0],
         R2 = lambda wc: sample_to_illumina[wc.sample][1],
-        db_index = lambda wc: "Logs/Databases/%s.kma_index.done" % species_configs[sample_to_organism[wc.sample]]['alignment_database']['kmeraligner']['kma_index_flag'],
-        db_dir = lambda wc: "%s" % getattr(rules, species_configs[sample_to_organism[wc.sample]]['alignment_database']['kmeraligner']['db']).output.database
+        db_index = lambda wc: "%s/%s.kma_index.done" %(database_path, species_configs[sample_to_organism[wc.sample]]['alignment_database']['kmeraligner']['kma_index_flag']),
+        db_dir = lambda wc: "%s" %getattr(rules, species_configs[sample_to_organism[wc.sample]]['alignment_database']['kmeraligner']['db']).output.database
     params:
         add_opt = lambda wc: species_configs[sample_to_organism[wc.sample]]["analyses_to_run"]["kmeraligner"]["additional_option"],
         prefix = lambda wc: "%s/%s/kmeraligner/%s" % (OUT_FOLDER, wc.sample, wc.sample),
@@ -31,6 +31,7 @@ rule kmeraligner:
         echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
         eval $cmd >> {log.stdout} 2>&1
         """
+
 
 rule KMA_filter:
     input:
@@ -58,6 +59,265 @@ rule KMA_filter:
 
         python workflow/scripts/KMAfilter.py --KMA_res {input.kma_res} --sample_id {params.id} --output {output.filtered_tsv} {params.add_opt} --log_dir {params.log_dir} > {log.stdout} 2>&1
         """
+
+
+rule samtools_index:
+    input:
+        bam = "{folder}/{sample}/FilteredBAM/{sample}.{tool}.filtered.sorted.bam"
+    output:
+        bai = temp("{folder}/{sample}/FilteredBAM/{sample}.{tool}.filtered.sorted.bam.bai")
+    conda:
+        config["analysis_settings"]["htslib"]["yaml"]
+    message:
+        "[samtools_index]: Indexing {input.bam} -> {output.bai}"
+    shell:
+        """
+        echo "Indexing {input.bam} -> {output.bai}"
+        samtools index {input.bam}
+        """
+
+
+rule samtools_view:
+    input:
+        sam = "{folder}/{sample}/{tool}/{sample}.sam"
+    output:
+        filtered_bam = "{folder}/{sample}/FilteredBAM/{sample}.{tool}.filtered.bam"
+    params:
+        add_opt = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["samtools_view"]["additional_option"]
+    conda:
+        config["analysis_settings"]["htslib"]["yaml"]
+    message:
+        "[samtools_view]: Filtering {input.sam} to {output.filtered_bam}"
+    shell:
+        """
+        echo "Filtering {input.sam} -> {output.filtered_bam}"
+        samtools view {params.add_opt} {input.sam} -o {output.filtered_bam}
+        """
+
+
+rule samtools_sort:
+    input:
+        bam = "{folder}/{sample}/FilteredBAM/{sample}.{tool}.filtered.bam",
+    output:
+        sorted_bam = "{folder}/{sample}/FilteredBAM/{sample}.{tool}.filtered.sorted.bam"
+    conda:
+        config["analysis_settings"]["htslib"]["yaml"]
+    message:
+        "[samtools_sort]: Sorting {input.bam} -> {output.sorted_bam}"
+    shell:
+        """
+        echo "Sorting {input.bam} -> {output.sorted_bam}"
+        samtools sort -o {output.sorted_bam} {input.bam}
+        """
+
+
+rule bcftools_index:
+    input:
+        bcf = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.{tag}.bcf"
+    output:
+        csi = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.{tag}.bcf.csi"
+    conda:
+        config["analysis_settings"]["htslib"]["yaml"]
+    message:
+        "[bcftools_index]: Indexing {input.bcf} -> {output.csi}"
+    shell:
+        """
+        echo "Indexing {input.bcf} -> {output.csi}"
+        bcftools index -f {input.bcf}
+        """
+
+
+rule bcftools_mpileup:
+    input:
+        bam = rules.samtools_sort.output.sorted_bam,
+        bai = rules.samtools_index.output.bai,
+        db_index = lambda wc: "%s/%s.fa_idx.done" %(database_path, species_configs[sample_to_organism[wc.sample]]['alignment_database']['kmeraligner']['fa_idx_flag']),
+        db_dir = lambda wc: "%s" % getattr(rules, species_configs[sample_to_organism[wc.sample]]['alignment_database']['kmeraligner']['db']).output.database
+    params:
+        db_prefix = lambda wc: species_configs[sample_to_organism[wc.sample]]["alignment_database"]['kmeraligner']["kma_db_prefix"]
+    output:
+        mpileup = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.mpileup.bcf"
+    conda:
+        config["analysis_settings"]["htslib"]["yaml"]
+    message:
+        "[bcftools_mpileup]: Generating mpileup {input.bam} -> {output.mpileup}"
+    shell:
+        """
+        bcftools mpileup -Ob -f {input.db_dir}/{params.db_prefix}.fasta {input.bam} -o {output.mpileup}
+        """
+
+        
+# Rule: bcftools_view_filter
+rule bcftools_view_filter:
+    input:
+        bcf = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.mpileup.bcf",
+        csi = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.mpileup.bcf.csi",  # ensure indexing happens
+    output:
+        indels_only = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.indels.bcf",
+    params:
+        region = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["bcftools_view_filter"]["region"],
+        add_opt = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["bcftools_view_filter"]["additional_option"],
+    conda:
+        config["analysis_settings"]["htslib"]["yaml"],
+    log:
+        stdout = '{folder}/{sample}/GenotypeCalls/{sample}.{tool}.bcftools_filter.log'
+    message:
+        "[bcftools_view_filter]: Filtering the mpileup from {input.bcf}",
+    shell:
+        """
+
+        cmd="bcftools view -r {params.region} {params.add_opt} -Ob -o {output.indels_only} {input.bcf}"
+
+        echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
+        eval $cmd >> {log.stdout} 2>&1
+        """
+
+
+rule bcftools_call:
+    input:
+        bcf = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.mpileup.bcf",
+        csi = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.mpileup.bcf.csi"
+    output:
+        genotypecall = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.calls.bcf"
+    conda:
+        config["analysis_settings"]["htslib"]["yaml"]
+    message:
+        "[bcftools_call]: Calling genotypes from {input.bcf} -> {output.genotypecall}"
+    shell:
+        """
+        bcftools call -mv -Ob --ploidy 1 {input.bcf} -o {output.genotypecall}
+        """    
+
+    
+rule Variant_identifier:
+    input:
+        genotype_call_bcf = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.calls.bcf",
+        indels_only_bcf = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.indels.bcf",
+        genotype_call_csi = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.calls.bcf.csi",
+        indels_only_csi = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.indels.bcf.csi",
+    output:
+        filtered_tsv = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.variants.tsv",
+    params:
+        input_folder = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["KMA_filter"]["input_folder"],
+        kma_res = lambda wildcards: os.path.join(
+            OUT_FOLDER,
+            wildcards.sample,
+            species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["KMA_filter"]["input_folder"],
+            "%s.res" % wildcards.sample
+        ),
+        kma_fsa = lambda wildcards: os.path.join(
+            OUT_FOLDER,
+            wildcards.sample,
+            species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["KMA_filter"]["input_folder"],
+            "%s.fsa" % wildcards.sample
+        ),
+        add_opt = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["Variant_detection"]["additional_option"],
+        log_dir = lambda wildcards: "%s/%s/GenotypeCalls/" % (OUT_FOLDER, wildcards.sample),
+        id = lambda wildcards: wildcards.sample,
+        region_buffer = 5,
+        overlap = 0.3,
+    log:
+        stdout = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.Variant_identifier.log"
+    conda:
+        config["analysis_settings"]["Variant_identifier"]["yaml"]
+    message:
+        "[Variant Identification]: Filtering KMA .res, KMA consensus .fsa, genotype calls and indels for {wildcards.sample}"
+    shell:
+        """
+        python workflow/scripts/Variant_identifier.py --sample_id {params.id}  --res {params.kma_res} --fsa {params.kma_fsa} --call {input.genotype_call_bcf} --indels {input.indels_only_bcf} {params.add_opt} -o {output.filtered_tsv} --deletion_region_buffer {params.region_buffer} --partial_overlap {params.overlap}
+        """
+
+
+# Rule: spades_assembly
+rule spades_assembly:
+    input:
+        R1 = lambda wildcards: sample_to_illumina[wildcards.sample][0],
+        R2 = lambda wildcards: sample_to_illumina[wildcards.sample][1],
+    output:
+        contigs = "%s/{sample}/spades/contigs.fasta" %OUT_FOLDER
+    conda:
+        config["analysis_settings"]["spades"]["yaml"]
+    log:
+        stdout = "Logs/{sample}/spades.log"
+    message:
+        "[spades_assembly]: Perform assembly using spades on {wildcards.sample}, this will take some time!"
+    threads:
+        min(workflow.cores - 1, 8)
+    shell:
+        """
+        cmd="spades.py -1 {input.R1} -2 {input.R2} --threads {threads} --isolate --only-assembler -o $(dirname {output.contigs})"
+
+        echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
+        eval $cmd >> {log.stdout} 2>&1
+        """
+
+
+# Rule: Skesa_assembly
+#  DeBruijn graph-based de-novo assembler for microbial genomes
+rule skesa_assembly:
+    input:
+        R1 = lambda wildcards: sample_to_illumina[wildcards.sample][0],
+        R2 = lambda wildcards: sample_to_illumina[wildcards.sample][1]
+    output:
+        assembly = "%s/{sample}/skesa/{sample}.contigs.fasta" %OUT_FOLDER
+    conda:
+        config["analysis_settings"]["skesa"]["yaml"]
+    log:
+        stdout = "Logs/{sample}/skesa.log"
+    message:
+        "[skesa_assembly]: Perform assembly using skesa on {wildcards.sample}, this will take some time!"
+    threads:
+        min(workflow.cores -1, 8)
+    shell:
+        """
+        mkdir -p $(dirname {output.assembly})
+        
+        cmd="skesa --reads {input.R1},{input.R2} --contigs_out {output.assembly} --cores {threads}"
+
+        echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
+        eval $cmd >> {log.stdout} 2>&1
+        """      
+
+
+rule Repeat_Identifier:
+    input:
+        fasta = lambda wildcards: os.path.join(
+            OUT_FOLDER,
+            wildcards.sample,
+            wildcards.assembler,
+            {
+                "spades": "contigs.fasta",
+                "skesa": "%s.contigs.fasta" % wildcards.sample
+            }[wildcards.assembler]
+        ),
+        repeat_fa = lambda wildcards: [
+            os.path.join(
+                species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["Repeat_identifier"]["database"],
+                "%s_repeat_sequences.fa" % repeats
+            )
+            for repeats in species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["Repeat_identifier"]["repeats"].split()
+        ]
+    output:
+        result = "%s/{sample}/Repeat_identifier/{assembler}_{sample}_repeat.tsv" %OUT_FOLDER
+    params:
+        repeats = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["Repeat_identifier"]["repeats"],
+        database = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["Repeat_identifier"]["database"],
+        combo_table = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["Repeat_identifier"]["combos"], 
+        out_dir = "%s/{sample}/Repeat_identifier" %OUT_FOLDER,
+        sample_id = lambda wildcards: "%s" % wildcards.sample
+    conda:
+        config["analysis_settings"]["Repeat_identifier"]["yaml"]
+    log:
+        stdout = "%s/{sample}/Repeat_identifier/{assembler}_{sample}_repeat.log" %OUT_FOLDER
+    message:
+        "[Repeat_identifier]: Running repeat analysis for {wildcards.sample} using ({wildcards.assembler}) contigs"
+    shell:
+        """
+        mkdir -p {params.out_dir}
+
+        python workflow/scripts/Repeat_Identifier.py --sample_id {params.sample_id} --fasta {input.fasta} --repeats {params.repeats} --combos {params.combo_table} --db_dir {params.database} --output {output.result} --suffix tsv > {log.stdout} 2>&1
+        """
+
 
 # Rule for emm typing using BLAST
 rule emm_typing:
@@ -123,250 +383,4 @@ rule assembly_lineage_determination:
                                                             --external {input.assembly} \
                                                             --name {params.name} \
                                                             --outputdir {output} \
-        """
-
-rule samtools_index:
-    input:
-        bam = "{folder}/{sample}/FilteredBAM/{sample}.{tool}.filtered.sorted.bam"
-    output:
-        bai = temp("{folder}/{sample}/FilteredBAM/{sample}.{tool}.filtered.sorted.bam.bai")
-    conda:
-        config["analysis_settings"]["htslib"]["yaml"]
-    message:
-        "[samtools_index]: Indexing {input.bam} -> {output.bai}"
-    shell:
-        """
-        echo "Indexing {input.bam} -> {output.bai}"
-        samtools index {input.bam}
-        """
-
-rule samtools_view:
-    input:
-        sam = "{folder}/{sample}/{tool}/{sample}.sam"
-    output:
-        filtered_bam = "{folder}/{sample}/FilteredBAM/{sample}.{tool}.filtered.bam"
-    params:
-        add_opt = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["samtools_view"]["additional_option"]
-    conda:
-        config["analysis_settings"]["htslib"]["yaml"]
-    message:
-        "[samtools_view]: Filtering {input.sam} to {output.filtered_bam}"
-    shell:
-        """
-        echo "Filtering {input.sam} -> {output.filtered_bam}"
-        samtools view {params.add_opt} {input.sam} -o {output.filtered_bam}
-        """
-
-rule samtools_sort:
-    input:
-        bam = "{folder}/{sample}/FilteredBAM/{sample}.{tool}.filtered.bam",
-    output:
-        sorted_bam = "{folder}/{sample}/FilteredBAM/{sample}.{tool}.filtered.sorted.bam"
-    conda:
-        config["analysis_settings"]["htslib"]["yaml"]
-    message:
-        "[samtools_sort]: Sorting {input.bam} -> {output.sorted_bam}"
-    shell:
-        """
-        echo "Sorting {input.bam} -> {output.sorted_bam}"
-        samtools sort -o {output.sorted_bam} {input.bam}
-        """
-
-rule bcftools_index:
-    input:
-        bcf = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.{tag}.bcf"
-    output:
-        csi = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.{tag}.bcf.csi"
-    conda:
-        config["analysis_settings"]["htslib"]["yaml"]
-    message:
-        "[bcftools_index]: Indexing {input.bcf} -> {output.csi}"
-    shell:
-        """
-        echo "Indexing {input.bcf} -> {output.csi}"
-        bcftools index -f {input.bcf}
-        """
-rule bcftools_mpileup:
-    input:
-        bam = rules.samtools_sort.output.sorted_bam,
-        bai = rules.samtools_index.output.bai,
-        db_index = lambda wc: "Logs/Databases/%s.fa_idx.done" % species_configs[sample_to_organism[wc.sample]]['alignment_database']['kmeraligner']['fa_idx_flag'],
-        db_dir = lambda wc: "%s" % getattr(rules, species_configs[sample_to_organism[wc.sample]]['alignment_database']['kmeraligner']['db']).output.database
-    params:
-        db_prefix = lambda wc: species_configs[sample_to_organism[wc.sample]]["alignment_database"]['kmeraligner']["kma_db_prefix"]
-    output:
-        mpileup = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.mpileup.bcf"
-    conda:
-        config["analysis_settings"]["htslib"]["yaml"]
-    message:
-        "[bcftools_mpileup]: Generating mpileup {input.bam} -> {output.mpileup}"
-    shell:
-        """
-        bcftools mpileup -Ob -f {input.db_dir}/{params.db_prefix}.fasta {input.bam} -o {output.mpileup}
-        """
-        
-# Rule: bcftools_view_filter
-rule bcftools_view_filter:
-    input:
-        bcf = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.mpileup.bcf",
-        csi = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.mpileup.bcf.csi",  # ensure indexing happens
-    output:
-        indels_only = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.indels.bcf",
-    params:
-        region = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["bcftools_view_filter"]["region"],
-        add_opt = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["bcftools_view_filter"]["additional_option"],
-    conda:
-        config["analysis_settings"]["htslib"]["yaml"],
-    log:
-        stdout = '{folder}/{sample}/GenotypeCalls/{sample}.{tool}.bcftools_filter.log'
-    message:
-        "[bcftools_view_filter]: Filtering the mpileup from {input.bcf}",
-    shell:
-        """
-
-        cmd="bcftools view -r {params.region} {params.add_opt} -Ob -o {output.indels_only} {input.bcf}"
-
-        echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
-        eval $cmd >> {log.stdout} 2>&1
-        """
-
-rule bcftools_call:
-    input:
-        bcf = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.mpileup.bcf",
-        csi = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.mpileup.bcf.csi"
-    output:
-        genotypecall = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.calls.bcf"
-    conda:
-        config["analysis_settings"]["htslib"]["yaml"]
-    message:
-        "[bcftools_call]: Calling genotypes from {input.bcf} -> {output.genotypecall}"
-    shell:
-        """
-        bcftools call -mv -Ob --ploidy 1 {input.bcf} -o {output.genotypecall}
-        """    
-    
-rule Variant_identifier:
-    input:
-        genotype_call_bcf = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.calls.bcf",
-        indels_only_bcf = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.indels.bcf",
-        genotype_call_csi = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.calls.bcf.csi",
-        indels_only_csi = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.indels.bcf.csi",
-    output:
-        filtered_tsv = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.variants.tsv",
-    params:
-        input_folder = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["KMA_filter"]["input_folder"],
-        kma_res = lambda wildcards: os.path.join(
-            OUT_FOLDER,
-            wildcards.sample,
-            species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["KMA_filter"]["input_folder"],
-            "%s.res" % wildcards.sample
-        ),
-        kma_fsa = lambda wildcards: os.path.join(
-            OUT_FOLDER,
-            wildcards.sample,
-            species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["KMA_filter"]["input_folder"],
-            "%s.fsa" % wildcards.sample
-        ),
-        add_opt = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["Variant_detection"]["additional_option"],
-        log_dir = lambda wildcards: "%s/%s/GenotypeCalls/" % (OUT_FOLDER, wildcards.sample),
-        id = lambda wildcards: wildcards.sample,
-        region_buffer = 5,
-        overlap = 0.3,
-    log:
-        stdout = "{folder}/{sample}/GenotypeCalls/{sample}.{tool}.Variant_identifier.log"
-    conda:
-        config["analysis_settings"]["Variant_identifier"]["yaml"]
-    message:
-        "[Variant Identification]: Filtering KMA .res, KMA consensus .fsa, genotype calls and indels for {wildcards.sample}"
-    shell:
-        """
-        python workflow/scripts/Variant_identifier.py --sample_id {params.id}  --res {params.kma_res} --fsa {params.kma_fsa} --call {input.genotype_call_bcf} --indels {input.indels_only_bcf} {params.add_opt} -o {output.filtered_tsv} --deletion_region_buffer {params.region_buffer} --partial_overlap {params.overlap}
-        """
-
-# Rule: spades_assembly
-rule spades_assembly:
-    input:
-        R1 = lambda wildcards: sample_to_illumina[wildcards.sample][0],
-        R2 = lambda wildcards: sample_to_illumina[wildcards.sample][1],
-    output:
-        contigs = "%s/{sample}/spades/contigs.fasta" %OUT_FOLDER
-    conda:
-        config["analysis_settings"]["spades"]["yaml"]
-    log:
-        stdout = "Logs/{sample}/spades.log"
-    message:
-        "[spades_assembly]: Perform assembly using spades on {wildcards.sample}, this will take some time!"
-    threads:
-        min(workflow.cores, 8)
-    shell:
-        """
-        cmd="spades.py -1 {input.R1} -2 {input.R2} --threads {threads} --isolate --only-assembler -o $(dirname {output.contigs})"
-
-        echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
-        eval $cmd >> {log.stdout} 2>&1
-        """
-
-# Rule: Skesa_assembly
-#  DeBruijn graph-based de-novo assembler for microbial genomes
-rule skesa_assembly:
-    input:
-        R1 = lambda wildcards: sample_to_illumina[wildcards.sample][0],
-        R2 = lambda wildcards: sample_to_illumina[wildcards.sample][1],
-    output:
-        assembly = "%s/{sample}/skesa/{sample}.contigs.fasta" %OUT_FOLDER
-    conda:
-        config["analysis_settings"]["skesa"]["yaml"]
-    log:
-        stdout = "Logs/{sample}/skesa.log"
-    message:
-        "[skesa_assembly]: Perform assembly using skesa on {wildcards.sample}, this will take some time!"
-    threads:
-        min(workflow.cores, 8)
-    shell:
-        """
-        mkdir -p $(dirname {output.assembly})
-        
-        cmd="skesa --reads {input.R1},{input.R2} --contigs_out {output.assembly} --cores {threads}"
-
-        echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
-        eval $cmd >> {log.stdout} 2>&1
-        """      
-
-rule Repeat_Identifier:
-    input:
-        fasta = lambda wildcards: os.path.join(
-            OUT_FOLDER,
-            wildcards.sample,
-            wildcards.assembler,
-            {
-                "spades": "contigs.fasta",
-                "skesa": "%s.contigs.fasta" % wildcards.sample
-            }[wildcards.assembler]
-        ),
-        repeat_fa = lambda wildcards: [
-            os.path.join(
-                species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["Repeat_identifier"]["database"],
-                "%s_repeat_sequences.fa" % repeats
-            )
-            for repeats in species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["Repeat_identifier"]["repeats"].split()
-        ]
-    output:
-        result = "%s/{sample}/Repeat_identifier/{assembler}_{sample}_repeat.tsv" %OUT_FOLDER
-    params:
-        repeats = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["Repeat_identifier"]["repeats"],
-        database = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["Repeat_identifier"]["database"],
-        combo_table = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["Repeat_identifier"]["combos"], 
-        out_dir = "%s/{sample}/Repeat_identifier" %OUT_FOLDER,
-        sample_id = lambda wildcards: "%s" % wildcards.sample
-    conda:
-        config["analysis_settings"]["Repeat_identifier"]["yaml"]
-    log:
-        stdout = "%s/{sample}/Repeat_identifier/{assembler}_{sample}_repeat.log" %OUT_FOLDER
-    message:
-        "[Repeat_identifier]: Running repeat analysis for {wildcards.sample} using ({wildcards.assembler}) contigs"
-    shell:
-        """
-        mkdir -p {params.out_dir}
-
-        python workflow/scripts/Repeat_Identifier.py --sample_id {params.sample_id} --fasta {input.fasta} --repeats {params.repeats} --combos {params.combo_table} --db_dir {params.database} --output {output.result} --suffix tsv > {log.stdout} 2>&1
         """


### PR DESCRIPTION
Database calls for CGE finders are now internalized in indipendent rules only, rather than using an independent generalized kmer indexing rule. AMRFinder output files has been renamed. Several samtools and bcftools rules where called explicitly in rule All despite not being final results.