### PR TITLE
generalized assemblers to accomodate both shovel assembly modes as we…

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -61,8 +61,22 @@ for species in set(sample_to_organism.values()):
 
 database_path = config['input_manager']['database_path']
 
-### Define rules where samtools is necessary
+# ------------- define specific assemblies as the might be rule specific -------------
+ASSEMBLIES = ["shovill_spades", "shovill_skesa", "spades", "skesa"]
+ASSEMBLIES_SHOVILL = ["shovill_spades", "shovill_skesa"]
+ASSEMBLIES_STANDALONE = ["spades", "skesa"]
 
+def assembly_path(wc):
+    """Return the expected contig path for the chosen assembler flavor."""
+    if wc.assembler.startswith("shovill_"):
+        # matches shovill_spades / shovill_skesa produced by rule `shovill`
+        return f"{OUT_FOLDER}/shovill/{wc.sample}/{wc.assembler}.fasta"
+    elif wc.assembler == "spades":
+        return f"{OUT_FOLDER}/spades/{wc.sample}/{wc.assembler}.fasta"
+    elif wc.assembler == "skesa":
+        return f"{OUT_FOLDER}/skesa/{wc.sample}/{wc.assembler}.fasta"
+    raise ValueError(f"Unknown assembler flavor: {wc.assembler}")
+# eventually the output structure should be changed to {wc.sample}/spades etc..
 
 ##############################################################################
 #
@@ -102,12 +116,12 @@ rule all:
             ]
         ),
         expand(
-            "%s/{sample}/AMRFinder/{assembly}.tsv" % OUT_FOLDER,
+            "%s/{sample}/AMRFinder/{assembler}.tsv" % OUT_FOLDER,
             sample = [
                 s for s in SAMPLES
                 if "amrfinder" in species_configs[sample_to_organism[s]]["analyses_to_run"]
             ],
-            assembly = ["spades", "skesa"]
+            assembler = ASSEMBLIES_SHOVILL
         ),
         expand(
            "%s/{sample}/MLST/{assembler}_mlst.tsv" % OUT_FOLDER,
@@ -115,7 +129,7 @@ rule all:
                s for s in SAMPLES 
                if "mlst" in species_configs[sample_to_organism[s]]["analyses_to_run"]
            ],
-           assembler = ["spades", "skesa"]
+           assembler = ASSEMBLIES_SHOVILL
         ),
         expand(
             "%s/{sample}/Variant_identifier/variants_{database}.tsv" %OUT_FOLDER,
@@ -131,7 +145,7 @@ rule all:
                 s for s in SAMPLES
                 if "CDiff_Repeat_identifier" in species_configs[sample_to_organism[s]]["analyses_to_run"]
             ],
-            assembler = ["spades", "skesa"]
+            assembler = ASSEMBLIES
         ),
         expand(
             "%s/{sample}/kmeraligner/{database}.res" % OUT_FOLDER,
@@ -147,7 +161,7 @@ rule all:
                 s for s in SAMPLES 
                 if "meningotype" in species_configs[sample_to_organism[s]]["analyses_to_run"]
             ],
-            assembler = "spades"
+            assembler = ["spades"]
         ),
 
 

--- a/workflow/envs/spades.yaml
+++ b/workflow/envs/spades.yaml
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 channels:
   - bioconda
   - conda-forge
@@ -6,11 +5,3 @@ channels:
 dependencies:
   - python
   - spades
-=======
-name: spades
-channels:
-    - conda-forge
-    - bioconda
-dependencies:
-    - spades
->>>>>>> N_Meningitidis_version_2_dev

--- a/workflow/rules/assemblers.smk
+++ b/workflow/rules/assemblers.smk
@@ -1,24 +1,95 @@
+#created a slight variation naming them according to the rules as well, such that it accomodates any potential seperate assembly rules
 rule shovill:
   input:
     R1 = lambda wildcards: sample_to_illumina[wildcards.sample][0],
     R2 = lambda wildcards: sample_to_illumina[wildcards.sample][1]
   output:
-    assembly = "%s/Assemblies/{sample}/{assembler}.fasta" %OUT_FOLDER
+    assembly = "%s/shovill/{sample}/{assembler}.fasta" % OUT_FOLDER
   conda:
     "../envs/shovill.yaml"
   log:
-    stdout = "Logs/Assemblies/{sample}_{assembler}.log"
+    stdout = "Logs/shovill/{sample}_{assembler}.log"
   threads:
-    workflow.cores * 0.66667
+    lambda wc: max(1, int(workflow.cores * 0.66667))
   message:
-    "[Shovill]: Assemblying {wildcards.sample} using {wildcards.assembler} with {threads} cores. This may take some time!\nInspect {log.stdout} for more details!"
+    "[Shovill]: Assembling {wildcards.sample} using {wildcards.assembler} with {threads} cores. This may take some time!\nInspect {log.stdout} for more details!"
   shell:
     """
     outdir=$(dirname {output.assembly})
-    assembler={wildcards.assembler}
+    assembler="$(echo "{wildcards.assembler}" | cut -d'_' -f2)"
+    echo "shovill assembler: \n $assembler \n"
 
-    cmd="shovill --R1 {input.R1} --R2 {input.R2} --outdir $outdir/$assembler --force --cpus {threads} --assembler $assembler --trim && mv $outdir/$assembler/contigs.fa {output.assembly}"
+    cmd="shovill --R1 {input.R1} --R2 {input.R2} --outdir $outdir/$assembler --force --cpus {threads} --trim --assembler $assembler"
+    echo "Executing command:\n$cmd\n" 
 
     echo "Executing command:\n$cmd\n" >> {log.stdout} 2>&1
     eval $cmd >> {log.stdout} 2>&1
+
+    cmd_asm="rm $outdir/$assembler/$assembler.fasta && mv $outdir/$assembler/contigs.fa {output.assembly}"
+    echo "Executing command:\n$cmd_asm\n"
+    echo "Executing command:\n$cmd_asm\n" >> {log.stdout} 2>&1
+    eval $cmd_asm >> {log.stdout} 2>&1
     """
+
+#consider adding this:
+#   params: extra = lambda wildcards: ("--noreadcorr --nocorr" if "skesa" in wildcards.assembler.lower() else "")
+# also eventually change the output folder structure to:
+#   assembly = "%s/{sample}/shovill/{assembler}.fasta" % OUT_FOLDER
+
+
+# Rule: spades_assembly
+rule spades:
+    input:
+        R1 = lambda wildcards: sample_to_illumina[wildcards.sample][0],
+        R2 = lambda wildcards: sample_to_illumina[wildcards.sample][1],
+    output:
+        assembly = "%s/spades/{sample}/{assembler}.fasta" % OUT_FOLDER
+    conda:
+        "../envs/spades.yaml"
+    log:
+        stdout = "Logs/spades/{sample}_{assembler}.log"
+    message:
+      "[spades_assembly]: Perform assembly using spades on {wildcards.sample}, this will take some time!"
+    threads:
+      lambda wc: max(1, int(workflow.cores * 0.66667))
+    shell:
+      """
+      outdir=$(dirname {output.assembly})
+      assembler={wildcards.assembler}
+      echo "assembler: \n $assembler \n"
+
+      cmd="spades.py -1 {input.R1} -2 {input.R2} --threads {threads} --isolate --only-assembler -o $outdir"
+      echo "Executing command:\n$cmd\n" 
+
+      echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
+      eval $cmd >> {log.stdout} 2>&1
+
+      cmd_asm="mv $outdir/contigs.fasta {output.assembly}"
+      echo "Executing command:\n$cmd_asm\n" >> {log.stdout} 2>&1
+      eval $cmd_asm >> {log.stdout} 2>&1
+      """
+
+# Rule: Skesa_assembly
+#  DeBruijn graph-based de-novo assembler for microbial genomes
+rule skesa:
+    input:
+        R1 = lambda wildcards: sample_to_illumina[wildcards.sample][0],
+        R2 = lambda wildcards: sample_to_illumina[wildcards.sample][1],
+    output:
+        assembly = "%s/skesa/{sample}/{assembler}.fasta" % OUT_FOLDER
+    conda:
+        "../envs/skesa.yaml"
+    log:
+        stdout = "Logs/skesa/{sample}_{assembler}.log"
+    message:
+        "[skesa_assembly]: Perform assembly using skesa on {wildcards.sample}, this will take some time!"
+    threads:
+      lambda wc: max(1, int(workflow.cores * 0.66667))
+    shell:
+      """
+      cmd="skesa --reads {input.R1},{input.R2} --contigs_out {output.assembly} --cores {threads}"
+      echo "Executing command:\n$cmd\n" 
+
+      echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
+      eval $cmd >> {log.stdout} 2>&1
+      """

--- a/workflow/rules/finders.smk
+++ b/workflow/rules/finders.smk
@@ -100,7 +100,7 @@ rule serotypefinder:
 
 rule AMRFinder:
     input:
-        assembly = rules.shovill.output.assembly,
+        assembly = assembly_path,
         database = rules.setup_AMRFinder.output.database
     params:
         # Point mutation
@@ -156,7 +156,7 @@ rule CDiff_Repeat_identifier:
   input:
     seqs  = expand(rules.fetch_type_repeat_sequence.output.seq, TR = ["TR6", "TR10"]),
     metas = expand(rules.fetch_type_repeat_metadata.output.meta, TR = ["TR6", "TR10", "TRST"]),
-    assembly = rules.shovill.output.assembly
+    assembly = assembly_path
   output:
     repeat_types = "%s/{sample}/CDiff_Repeat_identifier/{assembler}_repeat_types.tsv" %OUT_FOLDER
   params:


### PR DESCRIPTION
I have now:
- readded the independent skesa and spades assemblies necessary for C.diff repeat identifier
- renamed the shovill folder "Assemblies" to "shovil" to accomodate our own structure of naming it according to the rule as well as making it easier to distinguish the shovil (in spades and skesa mode) results from the actual skesa and spade results
- Generalized the rules such that the assembly input for example AMRfinder is not tied to the specific Shovill rule.

Therefore we can now add as many assembly tools as needed