### PR TITLE
split the KMA alignment (kmeralignment) into two seperate rules for a…

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -143,6 +143,14 @@ rule all:
             database = "ecoligenes"
         ),
         expand(
+            "%s/{sample}/kmerconsensus/{database}.fsa" % OUT_FOLDER,
+            sample = [
+                s for s in SAMPLES
+                if "kmerconsensus" in species_configs[sample_to_organism[s]]["analyses_to_run"]
+            ],
+            database = "ecoligenes"
+        ),
+        expand(
             "%s/{sample}/Kleborate/{assembler}" % OUT_FOLDER,
             sample=[
                 s for s in SAMPLES

--- a/workflow/configs_species/C.diff.yaml
+++ b/workflow/configs_species/C.diff.yaml
@@ -7,7 +7,12 @@ analyses_to_run:
     kmeraligner:
         Title : Kmer Aligner on two pair reads
         ID: 90
-        additional_option: -nc -ref_fsa -nf -sam 4
+        additional_option: -nc -nf -sam 4
+
+    kmerconsensus:
+        Title : Kmer consensus with 'N' from two pair reads
+        ID: 90
+        additional_option: -ref_fsa
 
     KMA_filter:
         Title : Kmer Aligner for Clostridium difficile Toxin detection

--- a/workflow/configs_species/E.coli.yaml
+++ b/workflow/configs_species/E.coli.yaml
@@ -39,7 +39,12 @@ analyses_to_run:
     kmeraligner:
         Title : Kmer Aligner on two pair reads
         ID: 90
-        additional_option :  -nc -ref_fsa -nf -sam 4
+        additional_option : -nc -nf -sam 4
+
+    kmerconsensus:
+        Title : Kmer consensus with 'N' from two pair reads
+        ID: 90
+        additional_option: -ref_fsa
 
     KMA_filter:
         Title : Kmer Aligner for Escherichia coli OH and stx typing

--- a/workflow/rules/finders.smk
+++ b/workflow/rules/finders.smk
@@ -127,7 +127,7 @@ rule AMRFinder:
 rule variant_identifier:
   input:
     kma_results = rules.custom_kmeralignment.output.results,
-    kma_seq = rules.custom_kmeralignment.output.seq,
+    kma_seq = rules.custom_kmerconsensus.output.seq,
     indels = rules.bcftools_filter_indels.output.indels,
     indels_index = "%s/{sample}/bcftools/{database}_indels.bcf.csi" %OUT_FOLDER,
     variants = rules.bcftools_variant_call.output.variants,

--- a/workflow/rules/mappers.smk
+++ b/workflow/rules/mappers.smk
@@ -8,7 +8,6 @@ rule custom_kmeralignment:
   output:
     results = "%s/{sample}/kmeraligner/{database}.res" %OUT_FOLDER,
     sam = temp("%s/{sample}/samtools/{database}.sam" %OUT_FOLDER),
-    seq = temp("%s/{sample}/kmeraligner/{database}.fsa" %OUT_FOLDER)
   conda:
     config["analysis_settings"]["KMA"]["yaml"]
   log:
@@ -23,11 +22,37 @@ rule custom_kmeralignment:
 
     db_path=$(dirname {input.database})/$(basename {input.database} .name)
 
-    cmd="kma -ipe {input.R1} {input.R2} -o {params.prefix} -t_db $db_path -nc -nf -ref_fsa -sam 4 > {output.sam}"
+    cmd="kma -ipe {input.R1} {input.R2} -o {params.prefix} -t_db $db_path -nc -nf -sam 4 > {output.sam}"
     echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
     eval $cmd >> {log.stdout} 2>&1
     """
 
+rule custom_kmerconsensus:
+  input:
+    R1 = lambda wildcards: sample_to_illumina[wildcards.sample][0],
+    R2 = lambda wildcards: sample_to_illumina[wildcards.sample][1],
+    database = rules.setup_custom_kmeraligner_index.output.names
+  params:
+    prefix = "%s/{sample}/kmerconsensus/{database}" %OUT_FOLDER
+  output:
+    results = temp("%s/{sample}/kmerconsensus/{database}.res" %OUT_FOLDER),
+    seq = "%s/{sample}/kmerconsensus/{database}.fsa" %OUT_FOLDER
+  conda:
+    config["analysis_settings"]["KMA"]["yaml"]
+  log:
+    stdout = "Logs/{sample}/custom_kmerconsensus_{database}.log"
+  message:
+    "[kmerconsensus]: Running KMA for {wildcards.database} on {wildcards.sample}"
+  shell:
+    """
+    mkdir -p $(dirname {output.seq})   
+
+    db_path=$(dirname {input.database})/$(basename {input.database} .name)
+
+    cmd="kma -ipe {input.R1} {input.R2} -o {params.prefix} -t_db $db_path -nf -ref_fsa"
+    echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
+    eval $cmd >> {log.stdout} 2>&1
+    """
 
 rule samtools_sam_filtration:
   input:


### PR DESCRIPTION
Split the kmeralignment rule into one alignment and one consensus creation rule, such that the issue of 100% coverage for alignment when also creating consensus is solved. The consensus sequence is still parsed to the variant identified together with the results from the alignment rule

Solves #58 