### PR TITLE
Enhancement: Added Intermediate cleanup rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ config/*yaml
 !config/results_catalogue.yaml
 *Results/
 MMAseq_Test/*
+*.swp

--- a/src/mmaseq/deploy.py
+++ b/src/mmaseq/deploy.py
@@ -135,10 +135,10 @@ def extract_hosts(urls):
     return hosts
 
 
-def connect_ftp(host):
+def connect_ftp(host, timeout = 45):
     logger.trace(f"Connecting to {host}")
 
-    ftp = ftplib.FTP(host)
+    ftp = ftplib.FTP(host, timeout = timeout)
 
     # Anonymous login
     ftp.login()

--- a/src/mmaseq/mmaseq.py
+++ b/src/mmaseq/mmaseq.py
@@ -86,6 +86,17 @@ def parse_mmaseq():
             "overwrite samplesheet. (Default: %(default)s)"
         )
     )
+    
+    parser.add_argument(
+        "--clean",
+        dest="clean",
+        action="store_false",
+        help=(
+            "Remove intermediate folders and files after completion. (Default: %(default)s) "
+            "If disabled, intermediate folders are maintained as OUTDIR/SAMPLE/raw/MODULE/ "
+            "while result files are copied to OUTDIR/SAMPLE/MODULE/"
+        )
+    )
 
     parser.add_argument(
         "--force",
@@ -387,21 +398,24 @@ def create_command(threads,
                    config_file, 
                    conda_dir,
                    force,
-                   arguments = None, 
-                   rules = None):
-    logger.trace(("create_command(\n - "
-                  f"config_file: {config_file}\n - "
-                  f"conda_dir: {conda_dir}\n - "
-                  f"force: {force}\n - "
-                  f"arguments: {arguments}\n - "
-                  f"rules: {rules})"))
+                   clean,
+                   arguments = None):
+    logger.trace(("create_command(\n"
+                  f"config_file={config_file}\n"
+                  f"conda_dir={conda_dir}\n"
+                  f"force={force}\n"
+                  f"clean={clean}\n"
+                  f"arguments={arguments})"))
 
     # Define arguments and rules as a single string
     additionals = " ".join(arguments) if arguments else ""
-    target_rules = " ".join(rules) if rules else ""
 
     if force:
-        additionals += " --forceall"
+        additionals += "--forceall "
+           
+    target_rule = "long "
+    if clean:
+        target_rule = "clean "
 
     # Determine command
     command = (
@@ -413,7 +427,7 @@ def create_command(threads,
         f"--snakefile {SNAKEFILE} "
         f"--conda-prefix {conda_dir} "
         f"{additionals} "
-        f"{target_rules}"
+        f"{target_rule}"
     )
 
     return command
@@ -433,6 +447,7 @@ def mmaseq(args):
     outdir = Path(args.outdir)
     threads = args.threads
     resolve = args.resolve
+    clean = args.clean
     force = args.force
     ignore_assemblies = args.ignore_assemblies
 
@@ -495,7 +510,8 @@ def mmaseq(args):
     command = create_command(threads,
                              config_file, 
                              conda_dir,
-                             force
+                             force,
+                             clean
                              )
 
     logger.info(

--- a/src/mmaseq/mmaseq.py
+++ b/src/mmaseq/mmaseq.py
@@ -413,7 +413,7 @@ def create_command(threads,
     if force:
         additionals += "--forceall "
            
-    target_rule = "long "
+    target_rule = "table "
     if clean:
         target_rule = "clean "
 

--- a/src/mmaseq/utils/result_paths.py
+++ b/src/mmaseq/utils/result_paths.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from .helpers import deconvolute_path, read_results_catalogue
 
 
-def define_module_results_file(outdir, sample, module, results_catalogue, sample_configs):
+def define_module_results_file(outdir, sample, module, results_catalogue, sample_configs, raw):
     """
     Defines the expected result file paths for a specific module and sample.
 
@@ -24,6 +24,9 @@ def define_module_results_file(outdir, sample, module, results_catalogue, sample
     """
     # Define prefix for result file paths
     prefix = Path(f"{outdir}/{sample}/{module}").expanduser()
+    if raw:
+        prefix = Path(f"{outdir}/{sample}/raw/{module}").expanduser()
+    
 
     # Define and normalise expected result file names
     result_strings = results_catalogue.get(module)
@@ -47,7 +50,7 @@ def define_module_results_file(outdir, sample, module, results_catalogue, sample
     return module_result_files
 
 
-def define_all_result_files(outdir, sample_configs, results_catalogue):
+def define_all_result_files(outdir, sample_configs, results_catalogue, raw):
     """
     Defines all expected result file paths for all samples and modules.
 
@@ -86,7 +89,7 @@ def define_all_result_files(outdir, sample_configs, results_catalogue):
             if not isinstance(configs, dict):
                 configs = dict()  # Not a dict means no keywords
 
-            result_files = define_module_results_file(outdir, sample, mod, results_catalogue, sample_configs)
+            result_files = define_module_results_file(outdir, sample, mod, results_catalogue, sample_configs, raw)
 
             all_result_files[sample].update({mod: result_files})
 

--- a/src/mmaseq/utils/results_aggregator.py
+++ b/src/mmaseq/utils/results_aggregator.py
@@ -53,9 +53,7 @@ def generate_long_results(all_result_files):
     for sample, modules in all_result_files.items():
 
         for mod, files in modules.items():
-
             for file in files:
-
                 try:
                     sample_results = pd.read_csv(file, sep = "\t", index_col = False)
                 except pd.errors.EmptyDataError:

--- a/src/mmaseq/workflow/Snakefile
+++ b/src/mmaseq/workflow/Snakefile
@@ -75,13 +75,11 @@ all_result_filepaths = [
 
 #################################
 logger.info("Initiating pipeline")
-rule copy_results:
+rule copy:
     input:
         raw = all_raw_result_filepaths
     output:
-        files = all_result_filepaths,
-        copied = temp("%s/copied.temp" %outdir)
-        
+        files = all_result_filepaths
     message:
         "[copy_results] Copying results files"
     shell:
@@ -94,35 +92,12 @@ rule copy_results:
             mkdir -p $NEWDIR
             cp -f $FILE $NEWDIR/
         done
-
-	echo "Copied" > {output.copied}
         """
 
 
-rule clean_results:
-    params:
-        raw = rules.copy_results.input.raw,
-    output:
-        cleaned = "%s/cleaned.temp" %outdir
-    message:
-        "[clean_results]: Removing intermediate folders"
-    shell:
-        """
-        for DIR in $(dirname {params.raw}); do
-           RAW=$(dirname $DIR)
-           if [ -d "$RAW" ]; then 
-               echo "Removing $RAW"
-               rm -r $RAW
-           fi
-        done
-        
-        echo "All intermediate folders have been removed." > {output.cleaned} 
-        """
-
-
-rule long:
+rule table:
     input:
-        copied = rules.copy_results.output.copied
+        files = rules.copy.output.files
     params:
         results_dict = all_result_files
     output:
@@ -136,8 +111,20 @@ rule long:
 
 rule clean:
     input:
-        clean = rules.clean_results.output.cleaned,
-        long = rules.long.output.long
+        long = rules.table.output.long,
+        raw = rules.copy.input.raw
+    message:
+        "[clean_results]: Removing intermediate folders"
+    shell:
+        """
+        for DIR in $(dirname {input.raw}); do
+           RAW=$(dirname $DIR)
+           if [ -d "$RAW" ]; then 
+               echo "Removing $RAW"
+               rm -r $RAW
+           fi
+        done
+        """
 
 
 include : "rules/db_fetch.smk"      

--- a/src/mmaseq/workflow/Snakefile
+++ b/src/mmaseq/workflow/Snakefile
@@ -49,9 +49,22 @@ sample_configs = sample_config.determine_sample_configs(samplesheet,
                                                            spe_configs_dir, 
                                                            ignore_assemblies)
 
+all_raw_result_files = result_paths.define_all_result_files(outdir, 
+                                                            sample_configs, 
+                                                            results_catalogue,
+                                                            raw=True)
 all_result_files = result_paths.define_all_result_files(outdir, 
-                                                        sample_configs, 
-                                                        results_catalogue)
+                                                            sample_configs, 
+                                                            results_catalogue,
+                                                            raw=False)
+
+all_raw_result_filepaths = [
+    path
+    for sample in all_raw_result_files.values()
+    for files in sample.values()
+    for path in files
+]
+
 
 all_result_filepaths = [
     path
@@ -60,19 +73,71 @@ all_result_filepaths = [
     for path in files
 ]
 
+#################################
 logger.info("Initiating pipeline")
-
-
-# Define the dynamic input for rule all
-###################################################################
-rule all:
+rule copy_results:
     input:
-        all = all_result_filepaths
+        raw = all_raw_result_filepaths
     output:
-        all = "%s/results_long.tsv" %outdir
+        files = all_result_filepaths,
+        copied = temp("%s/copied.temp" %outdir)
+        
+    message:
+        "[copy_results] Copying results files"
+    shell:
+        """
+        for FILE in {input.raw}; do
+            RAWDIR=$(dirname $FILE)
+            NEWDIR="${{RAWDIR//\\/raw\\//\\/}}"
+            
+            echo "Copying $FILE to $NEWDIR/"
+            mkdir -p $NEWDIR
+            cp -f $FILE $NEWDIR/
+        done
+
+	echo "Copied" > {output.copied}
+        """
+
+
+rule clean_results:
+    params:
+        raw = rules.copy_results.input.raw,
+    output:
+        cleaned = "%s/cleaned.temp" %outdir
+    message:
+        "[clean_results]: Removing intermediate folders"
+    shell:
+        """
+        for DIR in $(dirname {params.raw}); do
+           RAW=$(dirname $DIR)
+           if [ -d "$RAW" ]; then 
+               echo "Removing $RAW"
+               rm -r $RAW
+           fi
+        done
+        
+        echo "All intermediate folders have been removed." > {output.cleaned} 
+        """
+
+
+rule long:
+    input:
+        copied = rules.copy_results.output.copied
+    params:
+        results_dict = all_result_files
+    output:
+        long = "%s/results_long.tsv" %outdir
+    message:
+        "[keep]: Generating long table"
     run:
-        all_results_long = results_aggregator.generate_long_results(all_result_files)
-        all_results_long.to_csv(output.all, sep = "\t")
+        all_results_long = results_aggregator.generate_long_results(params.results_dict)
+        all_results_long.to_csv(output.long, sep = "\t")
+
+
+rule clean:
+    input:
+        clean = rules.clean_results.output.cleaned,
+        long = rules.long.output.long
 
 
 include : "rules/db_fetch.smk"      
@@ -83,6 +148,3 @@ include : "rules/variant_calling.smk"
 include : "rules/screening.smk"
 include : "rules/typing.smk"
 include : "rules/custom_analysis.smk"
-
-
-

--- a/src/mmaseq/workflow/rules/assemblers.smk
+++ b/src/mmaseq/workflow/rules/assemblers.smk
@@ -3,7 +3,7 @@ rule spades:
         R1 = lambda wc: samplesheet.loc[wc.sample, "read1"],
         R2 = lambda wc: samplesheet.loc[wc.sample, "read2"]
     output:
-        assembly = "%s/{sample}/spades/{sample}.fasta" %outdir
+        assembly = "%s/{sample}/raw/spades/{sample}.fasta" %outdir
     conda:
         ENVS_DIR / "shovill.yaml"
     log:
@@ -30,7 +30,7 @@ rule skesa:
         R1 = lambda wc: samplesheet.loc[wc.sample, "read1"],
         R2 = lambda wc: samplesheet.loc[wc.sample, "read2"]
     output:
-        assembly = "%s/{sample}/skesa/{sample}.fasta" %outdir
+        assembly = "%s/{sample}/raw/skesa/{sample}.fasta" %outdir
     conda:
         ENVS_DIR / "shovill.yaml"
     log:
@@ -52,7 +52,7 @@ rule shovill:
         R1 = lambda wc: samplesheet.loc[wc.sample, "read1"],
         R2 = lambda wc: samplesheet.loc[wc.sample, "read2"]
     output:
-        assembly = "%s/{sample}/shovill/{sample}.fasta" %outdir
+        assembly = "%s/{sample}/raw/shovill/{sample}.fasta" %outdir
     conda:
         ENVS_DIR / "shovill.yaml"
     log:
@@ -84,6 +84,9 @@ rule assembly:
         output_assembly = "%s/{sample}/Assemblies/{sample}_{assembler}.fasta" %outdir
     log:
         stdout = "%s/Assemblies/{sample}_{assembler}_assembly.log" %logdir
+    message:
+        "[assembly]: Moving {wildcards.assembler} assembly for {wildcards.sample} from raw location to assembly folder"
+ 
     shell:
         """
         mkdir -p $(dirname {output.output_assembly})

--- a/src/mmaseq/workflow/rules/custom_analysis.smk
+++ b/src/mmaseq/workflow/rules/custom_analysis.smk
@@ -6,7 +6,7 @@ rule snp_identifier:
         options = lambda wc: sample_configs[wc.sample]["snp_identifier"]["options"],
         metafile = "%s/SNP_metafile.tsv" %SCREENING_DIR
     output:
-        indentified_variants = "%s/{sample}/snp_identifier/{database}.tsv" %outdir
+        indentified_variants = "%s/{sample}/raw/snp_identifier/{database}.tsv" %outdir
     conda:
         ENVS_DIR / "py_utls.yaml"
     log:
@@ -33,7 +33,7 @@ rule deletion_identifier:
         options  = lambda wc: sample_configs[wc.sample]["deletion_identifier"]["options"],
         metafile = "%s/deletion_metafile.tsv" %SCREENING_DIR
     output:
-        identified_variants = f"{outdir}/{{sample}}/deletion_identifier/{{assembler,[^_]+}}_{{database}}.tsv" #added regex expression to ensure assemblies cannot contain '_' which our database also does
+        identified_variants = f"{outdir}/{{sample}}/raw/deletion_identifier/{{assembler,[^_]+}}_{{database}}.tsv" #added regex expression to ensure assemblies cannot contain '_' which our database also does
     conda:
         ENVS_DIR / "py_utls.yaml"
     log:
@@ -58,7 +58,7 @@ rule cdiff_repeat_identifier:
         repeats = lambda wc: sample_configs[wc.sample]["cdiff_repeat_identifier"]["repeats"],
         combos = lambda wc: sample_configs[wc.sample]["cdiff_repeat_identifier"]["combos"]
     output:
-        repeat_types = "%s/{sample}/cdiff_repeat_identifier/{assembler}_repeat_types.tsv" %outdir
+        repeat_types = "%s/{sample}/raw/cdiff_repeat_identifier/{assembler}_repeat_types.tsv" %outdir
     conda:
         ENVS_DIR / "py_utls.yaml"
     log:

--- a/src/mmaseq/workflow/rules/mappers.smk
+++ b/src/mmaseq/workflow/rules/mappers.smk
@@ -4,13 +4,12 @@ rule custom_kmeralignment:
         R2 = lambda wc: samplesheet.loc[wc.sample, "read2"],
         database = rules.setup_custom_kmeraligner_index.output.names
     params:
-        prefix_out = "%s/{sample}/kmeraligner/{database}" %outdir,
         prefix_db = rules.setup_custom_kmeraligner_index.params.prefix    
     output:
-        results = "%s/{sample}/kmeraligner/{database}.res" %outdir,
-        sam = temp("%s/{sample}/samtools/{database}.sam" %outdir),
-        matrix = temp("%s/{sample}/kmeraligner/{database}.mat.gz" %outdir),
-        tool_version = "%s/{sample}/kmeraligner/{database}_kmaalign_version.txt" %outdir,
+        results = "%s/{sample}/raw/kmeraligner/{database}.res" %outdir,
+        sam = temp("%s/{sample}/raw/samtools/{database}.sam" %outdir),
+        matrix = temp("%s/{sample}/raw/kmeraligner/{database}.mat.gz" %outdir),
+        tool_version = "%s/{sample}/raw/kmeraligner/{database}_kmaalign_version.txt" %outdir,
     conda:
         ENVS_DIR / "kmeraligner.yaml"
     log:
@@ -19,10 +18,13 @@ rule custom_kmeralignment:
         "[kmeraligner]: Running KMA for {wildcards.database} on {wildcards.sample}"
     shell:
         """
-        mkdir -p $(dirname {output.results})
-        mkdir -p $(dirname {output.sam})
+        OUTDIR=$(dirname {output.results})
+        SAMDIR=$(dirname {output.sam})
 
-        cmd="kma -ipe {input.R1} {input.R2} -o {params.prefix_out} -t_db {params.prefix_db} -na -nc -nf -sam 4 -matrix > {output.sam}"
+        mkdir -p $OUTDIR
+        mkdir -p $SAMDIR
+
+        cmd="kma -ipe {input.R1} {input.R2} -o $OUTDIR/{wildcards.database} -t_db {params.prefix_db} -na -nc -nf -sam 4 -matrix > {output.sam}"
 
         echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
         eval $cmd >> {log.stdout} 2>&1
@@ -45,13 +47,12 @@ rule custom_kmerconsensus:
         R2 = lambda wc: samplesheet.loc[wc.sample, "read2"],
         database = rules.setup_custom_kmeraligner_index.output.names
     params:
-        prefix_out = "%s/{sample}/kmerconsensus/{database}" %outdir,
         prefix_db = rules.setup_custom_kmeraligner_index.params.prefix,
     output:
-        results = temp("%s/{sample}/kmerconsensus/{database}.res" %outdir),
-        seq = "%s/{sample}/kmerconsensus/{database}.fsa" %outdir,
-        aln = temp("%s/{sample}/kmerconsensus/{database}.aln" %outdir),
-        tool_version = "%s/{sample}/kmerconsensus/{database}_kmaconsensus_version.txt" %outdir,
+        results = temp("%s/{sample}/raw/kmerconsensus/{database}.res" %outdir),
+        seq = "%s/{sample}/raw/kmerconsensus/{database}.fsa" %outdir,
+        aln = temp("%s/{sample}/raw/kmerconsensus/{database}.aln" %outdir),
+        tool_version = "%s/{sample}/raw/kmerconsensus/{database}_kmaconsensus_version.txt" %outdir,
     conda:
         ENVS_DIR / "kmeraligner.yaml"
     log:
@@ -60,9 +61,11 @@ rule custom_kmerconsensus:
         "[kmerconsensus]: Running KMA for {wildcards.database} on {wildcards.sample}"
     shell:
         """
-        mkdir -p $(dirname {output.seq})
+        OUTDIR=$(dirname {output.seq})
 
-        cmd="kma -ipe {input.R1} {input.R2} -o {params.prefix_out} -t_db {params.prefix_db} -nf -ref_fsa"
+        
+        mkdir -p $OUTDIR
+        cmd="kma -ipe {input.R1} {input.R2} -o $OUTDIR/{wildcards.database} -t_db {params.prefix_db} -nf -ref_fsa"
         echo "Executing command:\n$cmd\n" > {log.stdout} 2>&1
         eval $cmd >> {log.stdout} 2>&1
 
@@ -86,7 +89,7 @@ rule custom_bowtie2alignment:
     params:
        options = lambda wc: sample_configs[wc.sample]["custom_bowtie2alignment"]["options"]
     output:
-        sam = temp("%s/{sample}/bowtie2/{database}.sam" %outdir)
+        sam = temp("%s/{sample}/raw/bowtie2/{database}.sam" %outdir)
     threads: max(1, workflow.cores - 1 - (workflow.cores - 1) % 2)
     priority: 1
     conda:
@@ -115,7 +118,7 @@ rule assembly_minimap2:
     params:
         options = lambda wc: sample_configs[wc.sample]["assembly_minimap2"]["options"]
     output:
-        results = temp(f"{outdir}/{{sample}}/minimap2/{{assembler}}_{{database}}.sam")
+        results = temp(f"{outdir}/{{sample}}/raw/minimap2/{{assembler}}_{{database}}.sam")
     conda:
         ENVS_DIR / "minimap2.yaml"
     log:
@@ -141,7 +144,7 @@ rule kma_filter:
         options = lambda wildcards: sample_configs[wildcards.sample]["kma_filter"]["options"],
         metafile = "%s/kma_filter.tsv" %SCREENING_DIR
     output:
-        filtered_tsv = "%s/{sample}/kma_filter/{database}.tsv" % outdir
+        filtered_tsv = "%s/{sample}/raw/kma_filter/{database}.tsv" % outdir
     conda:
         ENVS_DIR / "py_utls.yaml"
     log:

--- a/src/mmaseq/workflow/rules/screening.smk
+++ b/src/mmaseq/workflow/rules/screening.smk
@@ -5,8 +5,7 @@ rule plasmidfinder:
         R2 = lambda wc: samplesheet.loc[wc.sample, "read2"],
         database = rules.setup_PlasmidFinder.output.database
     output:
-        # Output directory for plasmidfinder results.
-        replicons = "%s/{sample}/plasmidfinder/results_tab.tsv" %outdir
+        replicons = "%s/{sample}/raw/plasmidfinder/results_tab.tsv" %outdir
     conda:
         ENVS_DIR / "CGE_finders.yaml"
     log:
@@ -34,8 +33,8 @@ rule resfinder:
     params:
         options = lambda wc: sample_configs[wc.sample]["resfinder"]["options"]
     output:
-        resistance = "%s/{sample}/resfinder/ResFinder_results_tab.txt" %outdir,
-        tool_version = "%s/{sample}/resfinder/ResFinder_version.txt" %outdir,
+        resistance = "%s/{sample}/raw/resfinder/ResFinder_results_tab.txt" %outdir,
+        tool_version = "%s/{sample}/raw/resfinder/ResFinder_version.txt" %outdir,
     conda:
         ENVS_DIR / "CGE_finders.yaml"
     log:
@@ -73,7 +72,7 @@ rule virulencefinder:
         R2 = lambda wc: samplesheet.loc[wc.sample, "read2"],
         database = rules.setup_VirulenceFinder.output.database
     output:
-        virulence = "%s/{sample}/virulencefinder/results_tab.tsv" %outdir,
+        virulence = "%s/{sample}/raw/virulencefinder/results_tab.tsv" %outdir,
     conda:
         ENVS_DIR / "CGE_finders.yaml"
     log:
@@ -97,8 +96,8 @@ rule amrfinder:
     params:
         options = lambda wc: sample_configs[wc.sample]["amrfinder"]["options"]
     output:
-        result = "%s/{sample}/amrfinder/{assembler}.tsv" %outdir,
-        tool_version = "%s/{sample}/amrfinder/{assembler}_amrfinder_version.txt" %outdir,
+        result = "%s/{sample}/raw/amrfinder/{assembler}.tsv" %outdir,
+        tool_version = "%s/{sample}/raw/amrfinder/{assembler}_amrfinder_version.txt" %outdir,
     conda:
         ENVS_DIR / "amrfinder.yaml"
     log:
@@ -128,13 +127,12 @@ rule amrfinder:
 
 rule LREfinder:
     input:
-        # A complete access to the wildcard is needed, if we try to call the output of different rule we have the blending of wildcards 
         res = rules.custom_kmeralignment.output.results,
         matrix = rules.custom_kmeralignment.output.matrix
     # params:
     #     options = lambda wildcards: species_configs[sample_to_organism[wildcards.sample]]["analyses_to_run"]["custom_blaster"]["options"],    
     output:
-        results = "%s/{sample}/LREfinder/{database}.tsv" %outdir,
+        results = "%s/{sample}/raw/LREfinder/{database}.tsv" %outdir,
     conda:
         ENVS_DIR / "py_utls.yaml"
     log:
@@ -161,8 +159,8 @@ rule custom_blaster:
     params:
         options = lambda wc: sample_configs[wc.sample]["custom_blaster"]["options"]
     output:
-        results = "%s/{sample}/custom_blaster/blast_{assembler}_{database}.tsv" %outdir,
-        tool_version = "%s/{sample}/custom_blaster/blast_{assembler}_{database}_version.txt" %outdir,
+        results = "%s/{sample}/raw/custom_blaster/blast_{assembler}_{database}.tsv" %outdir,
+        tool_version = "%s/{sample}/raw/custom_blaster/blast_{assembler}_{database}_version.txt" %outdir,
     conda:
         ENVS_DIR / "blast.yaml"
     log:

--- a/src/mmaseq/workflow/rules/typing.smk
+++ b/src/mmaseq/workflow/rules/typing.smk
@@ -4,9 +4,9 @@ rule mlst:
     input:
         assembly = rules.assembly.output.output_assembly
     output:
-        mlst_file = "%s/{sample}/mlst/{assembler}_mlst.tsv" %outdir,
-        mlst_tmp = temp("%s/{sample}/mlst/{assembler}_mlst.mp" %outdir),
-        tool_version = "%s/{sample}/mlst/{assembler}_mlst_version.txt" %outdir,
+        mlst_file = "%s/{sample}/raw/mlst/{assembler}_mlst.tsv" %outdir,
+        mlst_tmp = temp("%s/{sample}/raw/mlst/{assembler}_mlst.mp" %outdir),
+        tool_version = "%s/{sample}/raw/mlst/{assembler}_mlst_version.txt" %outdir,
     conda:
         ENVS_DIR / "mlst.yaml"
     log:
@@ -43,7 +43,7 @@ rule kleborate:
         assembly = rules.assembly.output.output_assembly,
         version_db = rules.setup_kleborate_amrfinder.output.version_db
     output:
-        kleborate = "%s/{sample}/kleborate/{assembler}/Kleborate_long.tsv" %outdir
+        kleborate = "%s/{sample}/raw/kleborate/{assembler}/Kleborate_long.tsv" %outdir
     params:
         options = lambda wildcards: sample_configs[wildcards.sample]["kleborate"]["options"]
     conda:
@@ -90,7 +90,7 @@ rule chtyper:
         id = 90,
         coverage = 60
     output:
-        filtered_tsv = "%s/{sample}/chtyper/{database}_chtyper.tsv" % outdir
+        filtered_tsv = "%s/{sample}/raw/chtyper/{database}_chtyper.tsv" % outdir
     log:
         stdout = "%s/{sample}/{database}_chtyper.log" %logdir
     message:
@@ -111,8 +111,8 @@ rule meningotype:
     input:
         assembly = rules.assembly.output.output_assembly,
     output:
-        meningotype = "%s/{sample}/meningotype/{assembler}_meningotype.tsv" %outdir,
-        tool_version = "%s/{sample}/meningotype/{assembler}_meningotype_version.txt" %outdir,
+        meningotype = "%s/{sample}/raw/meningotype/{assembler}_meningotype.tsv" %outdir,
+        tool_version = "%s/{sample}/raw/meningotype/{assembler}_meningotype_version.txt" %outdir,
     conda:
         ENVS_DIR / "meningotype.yaml"
     log:
@@ -146,8 +146,8 @@ rule seqsero2:
         R1 = lambda wc: samplesheet.loc[wc.sample, "read1"],
         R2 = lambda wc: samplesheet.loc[wc.sample, "read2"]
     output:
-        seqsero = "%s/{sample}/seqsero2/SeqSero_result.tsv" %outdir,
-        tool_version = "%s/{sample}/seqsero2/SeqSero_version.txt" %outdir,
+        seqsero = "%s/{sample}/raw/seqsero2/SeqSero_result.tsv" %outdir,
+        tool_version = "%s/{sample}/raw/seqsero2/SeqSero_version.txt" %outdir,
     threads: max(1, workflow.cores - 1 - (workflow.cores - 1) % 2)
     priority: 1
     conda:
@@ -183,10 +183,10 @@ rule sistr:
         assembly = rules.assembly.output.output_assembly,
         serovarlist = rules.fetch_Senterica_Serovar.output.source
     output:
-        sistr_tab = "%s/{sample}/sistr/{assembler}_sistr.tab" %outdir,
-        gmlst_profile = "%s/{sample}/sistr/{assembler}_cgmlst_profiles.csv" %outdir,
-        allele_results = "%s/{sample}/sistr/{assembler}_allele-results.json" %outdir,
-        tool_version = "%s/{sample}/sistr/{assembler}_sistr_version.txt" %outdir,
+        sistr_tab = "%s/{sample}/raw/sistr/{assembler}_sistr.tab" %outdir,
+        gmlst_profile = "%s/{sample}/raw/sistr/{assembler}_cgmlst_profiles.csv" %outdir,
+        allele_results = "%s/{sample}/raw/sistr/{assembler}_allele-results.json" %outdir,
+        tool_version = "%s/{sample}/raw/sistr/{assembler}_sistr_version.txt" %outdir,
     threads: max(1, workflow.cores - 1 - (workflow.cores - 1) % 2)
     priority: 1
     conda:
@@ -223,7 +223,7 @@ rule serotypefinder:
         R2 = lambda wc: samplesheet.loc[wc.sample, "read2"],
         database = rules.setup_SerotypeFinder.output.database
     output:
-        serotype = "%s/{sample}/serotypefinder/results_tab.tsv" %outdir,
+        serotype = "%s/{sample}/raw/serotypefinder/results_tab.tsv" %outdir,
     conda:
         ENVS_DIR / "CGE_finders.yaml"
     log:
@@ -244,7 +244,7 @@ rule spa_typing:
         assembly = rules.assembly.output.output_assembly,
         database = rules.setup_Spatyper.output.database
     output:
-        spatyper = "%s/{sample}/spatyper/{assembler}_spatype_results.tsv" %outdir
+        spatyper = "%s/{sample}/raw/spatyper/{assembler}_spatype_results.tsv" %outdir
     conda:
         ENVS_DIR / "py_utls.yaml"
     log:

--- a/src/mmaseq/workflow/rules/variant_calling.smk
+++ b/src/mmaseq/workflow/rules/variant_calling.smk
@@ -1,10 +1,10 @@
 rule samtools_sam_filtration:
     input:
-        sam = "%s/{sample}/samtools/{database}.sam" %outdir
+        sam = "%s/{sample}/raw/samtools/{database}.sam" %outdir
     params:
         options = lambda wc: sample_configs[wc.sample]["samtools"]["view_options"]
     output:
-        bam = temp("%s/{sample}/samtools/{database}_filtered.bam" %outdir)
+        bam = temp("%s/{sample}/raw/samtools/{database}_filtered.bam" %outdir)
     conda:
         ENVS_DIR / "htslib.yaml"
     log:
@@ -22,11 +22,11 @@ rule samtools_sam_filtration:
 
 rule samtools_bam_filtration:
     input:
-        bam = "%s/{sample}/samtools/{database}.bam" %outdir
+        bam = "%s/{sample}/raw/samtools/{database}.bam" %outdir
     params:
         options = lambda wc: sample_configs[wc.sample]["samtools"]["view_options"]
     output:
-        bam = temp("%s/{sample}/samtools/{database}_filtered.bam" %outdir)
+        bam = temp("%s/{sample}/raw/samtools/{database}_filtered.bam" %outdir)
     conda:
         ENVS_DIR / "htslib.yaml"
     log:
@@ -44,12 +44,12 @@ rule samtools_bam_filtration:
 
 rule samtools_sort:
     input:
-        bam = "%s/{sample}/samtools/{database}_filtered.bam" %outdir
+        bam = "%s/{sample}/raw/samtools/{database}_filtered.bam" %outdir
     params:
         options = lambda wc: sample_configs[wc.sample]["samtools"]["sort_options"]
     output:
-        bam_sort = temp("%s/{sample}/samtools/{database}_sorted.bam" %outdir),
-        index = temp("%s/{sample}/samtools/{database}_sorted.bam.bai" %outdir)
+        bam_sort = temp("%s/{sample}/raw/samtools/{database}_sorted.bam" %outdir),
+        index = temp("%s/{sample}/raw/samtools/{database}_sorted.bam.bai" %outdir)
     conda:
         ENVS_DIR / "htslib.yaml"
     log:
@@ -75,8 +75,8 @@ rule bcftools_pileup:
         bam_sort = rules.samtools_sort.output.bam_sort,
         reference = "%s/samtools/{database}.fasta" %database_dir
     output:
-        pileup = temp("%s/{sample}/bcftools/{database}_pileup.bcf" %outdir),
-        index = temp("%s/{sample}/bcftools/{database}_pileup.bcf.csi" %outdir)
+        pileup = temp("%s/{sample}/raw/bcftools/{database}_pileup.bcf" %outdir),
+        index = temp("%s/{sample}/raw/bcftools/{database}_pileup.bcf.csi" %outdir)
     conda:
         ENVS_DIR / "htslib.yaml"
     log:
@@ -104,8 +104,8 @@ rule bcftools_filter_indels:
     params:
         options = lambda wc: sample_configs[wc.sample]["bcftools"]["view_options"]
     output:
-        indels = temp("%s/{sample}/bcftools/{database}_pileup_indels.bcf" %outdir),
-        index = temp("%s/{sample}/bcftools/{database}_pileup_indels.bcf.csi" %outdir)
+        indels = temp("%s/{sample}/raw/bcftools/{database}_pileup_indels.bcf" %outdir),
+        index = temp("%s/{sample}/raw/bcftools/{database}_pileup_indels.bcf.csi" %outdir)
     conda:
         ENVS_DIR / "htslib.yaml"
     log:
@@ -131,8 +131,8 @@ rule bcftools_variant_call:
         pileup = rules.bcftools_pileup.output.pileup,
         pileup_index = rules.bcftools_pileup.output.index,
     output: 
-        variants = temp("%s/{sample}/bcftools/{database}_call_variants.bcf" %outdir),
-        index = temp("%s/{sample}/bcftools/{database}_call_variants.bcf.csi" %outdir)
+        variants = temp("%s/{sample}/raw/bcftools/{database}_call_variants.bcf" %outdir),
+        index = temp("%s/{sample}/raw/bcftools/{database}_call_variants.bcf.csi" %outdir)
     conda:
         ENVS_DIR / "htslib.yaml"
     log:


### PR DESCRIPTION
*All rules now write to {sample}/raw/{module} to enable easy cleaning
* mmaseq module now has a --clean T/F argument (default T), when active, it removes intermediate files
* rule all has been renamed to rule long
* rule copy, clean_results, and clean has been added to Snakefile
* rule long gets input from rule copy which copies result catalogue files out of the {sample}/raw/{module} to {sample}/{module} folders.
* rule clean gets input from rule long AND rule clean_results