### PR TITLE
Fix pip installation duplication err

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ Documentation = "https://ssi-dk.github.io/MMASeq"
 Repository = "https://github.com/ssi-dk/MMASeq"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/mmaseq", "src/mmaseq/utils"]
+packages = ["src/mmaseq"]
 
 [tool.hatch.build.targets.sdist]
 only-include = ["src/mmaseq", "README.md", "LICENSE", "pyproject.toml"]
@@ -41,9 +41,6 @@ exclude = [
   "**/__pycache__/**",
   "**/.snakemake/**"
 ]
-
-[tool.hatch.build.targets.wheel.force-include]
-"src/mmaseq/data/reads/reads.urls" = "src/mmaseq/data/reads/reads.urls"
 
 [project.scripts]
 mmadeploy = "mmaseq.deploy:launcher"


### PR DESCRIPTION
* Removed redundant line including src/mmaseq/utils which occationally caused a pip install dupplication err
* Removed redundant force includion of the data/reads.url which is allready included