### PR TITLE
Fix typo in vancomycin operon URL

### DIFF
--- a/src/mmaseq/workflow/rules/db_fetch.smk
+++ b/src/mmaseq/workflow/rules/db_fetch.smk
@@ -327,7 +327,7 @@ rule fetch_vancomycin_operon:
         OUTDIR=$(dirname {output.source})
         mkdir -p $OUTDIR
                 
-        fasta_url="https://raw.githubusercontent.com/ssi-dk/ssi_analysis_utility_db/refs/heads/main/resistance/vancomycin_operon.fasta"
+        fasta_url="https://raw.githubusercontent.com/ssi-dk/ssi_analysis_utility_db/refs/heads/main/resistance/vancomycinOperon.fasta"
 
         cmd="curl -fSL $fasta_url -o {output.source}"
 


### PR DESCRIPTION
This suggests tests did not cover downloading this database, or a test for the correctness of URLs. This would be a good idea, since URLs go stale.