### PR TITLE
Build PR label check to use correct PR number

### DIFF
--- a/.github/workflows/PR_label_check.yml
+++ b/.github/workflows/PR_label_check.yml
@@ -14,10 +14,24 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const run = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id
+            });
+            
+            // Get PR number from workflow run
+            const pr_number = run.data.pull_requests[0]?.number;
+            
+            if (!pr_number) {
+              core.setFailed('Could not find associated pull request');
+              return;
+            }
+            
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number
+              pull_number: pr_number
             });
             
             const labels = pr.data.labels


### PR DESCRIPTION
* Changed from ID workflow from Action run nr to ID with PR number instead