### PR TITLE
Add automatic labeling workflow for issue comments

### DIFF
--- a/.github/workflows/COMMENTS.yml
+++ b/.github/workflows/COMMENTS.yml
@@ -1,0 +1,94 @@
+name: Automatic comments
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  feature:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Enable feature label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body.trim();
+            if (body !== "\\feature") return;
+            
+            const user = context.payload.comment.user.login;
+
+            const perm = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: user
+            });
+
+            if (!["admin", "write"].includes(perm.data.permission)) return;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ["feature"]
+            });
+
+  patch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Enable feature label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body.trim();
+            if (body !== "\\patch") return;
+
+            const user = context.payload.comment.user.login;
+
+            const perm = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: user
+            });
+
+            if (!["admin", "write"].includes(perm.data.permission)) return;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ["patch"]
+            });
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Enable feature label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body.trim();
+            if (body !== "\\build") return;
+
+            const user = context.payload.comment.user.login;
+
+            const perm = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: user
+            });
+
+            if (!["admin", "write"].includes(perm.data.permission)) return;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ["build"]
+            });

--- a/.github/workflows/COMMENTS.yml
+++ b/.github/workflows/COMMENTS.yml
@@ -25,20 +25,25 @@ jobs:
             };
 
             const label = mapping[body];
-
             if (!label) return;
 
             const user = context.payload.comment.user.login;
 
-            const perm =
-              await github.rest.repos.getCollaboratorPermissionLevel({
+            const perm = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: user
+            });
+
+            if (!["admin", "write"].includes(perm.data.permission)) {
+              await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                username: user
+                issue_number: context.issue.number,
+                body: "❌ You don't have permission to change version labels."
               });
-
-            if (!["admin", "write"].includes(perm.data.permission))
               return;
+            }
 
             const issue_number = context.issue.number;
 
@@ -51,21 +56,19 @@ jobs:
 
             const versionLabels = ["feature", "patch", "build"];
 
-            // remove existing version labels
+            // remove old version labels
             for (const existing of issue.data.labels.map(l => l.name)) {
               if (!versionLabels.includes(existing)) continue;
 
-              try {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number,
-                  name: existing
-                });
-              } catch {}
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: repo,
+                issue_number,
+                name: existing
+              });
             }
 
-            // add requested label
+            // apply new label
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -73,27 +76,10 @@ jobs:
               labels: [label]
             });
 
-  check-label:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Validate labels
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = await github.rest.pulls.get({
+            // feedback
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number
+              issue_number,
+              body: `✅ Version label set to **${label}**`
             });
-
-            const allowed = ["feature", "patch", "build"];
-
-            const labels = pr.data.labels
-              .map(l => l.name)
-              .filter(l => allowed.includes(l));
-
-            if (labels.length !== 1) {
-              core.setFailed(`Must have exactly one version label. Found: ${labels.join(", ")}`);
-            }

--- a/.github/workflows/COMMENTS.yml
+++ b/.github/workflows/COMMENTS.yml
@@ -9,86 +9,91 @@ permissions:
   pull-requests: write
 
 jobs:
-  feature:
+  version-label:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Enable feature label
-        uses: actions/github-script@v7
+      - uses: actions/github-script@v7
         with:
           script: |
             const body = context.payload.comment.body.trim();
-            if (body !== "\\feature") return;
-            
+
+            const mapping = {
+              "\\feature": "feature",
+              "\\patch": "patch",
+              "\\build": "build"
+            };
+
+            const label = mapping[body];
+
+            if (!label) return;
+
             const user = context.payload.comment.user.login;
 
-            const perm = await github.rest.repos.getCollaboratorPermissionLevel({
+            const perm =
+              await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: user
+              });
+
+            if (!["admin", "write"].includes(perm.data.permission))
+              return;
+
+            const issue_number = context.issue.number;
+
+            // fetch current labels
+            const issue = await github.rest.issues.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              username: user
+              issue_number
             });
 
-            if (!["admin", "write"].includes(perm.data.permission)) return;
+            const versionLabels = ["feature", "patch", "build"];
 
+            // remove existing version labels
+            for (const existing of issue.data.labels.map(l => l.name)) {
+              if (!versionLabels.includes(existing)) continue;
+
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  name: existing
+                });
+              } catch {}
+            }
+
+            // add requested label
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ["feature"]
+              issue_number,
+              labels: [label]
             });
 
-  patch:
+  check-label:
+
     runs-on: ubuntu-latest
 
     steps:
-      - name: Enable feature label
+      - name: Validate labels
         uses: actions/github-script@v7
         with:
           script: |
-            const body = context.payload.comment.body.trim();
-            if (body !== "\\patch") return;
-
-            const user = context.payload.comment.user.login;
-
-            const perm = await github.rest.repos.getCollaboratorPermissionLevel({
+            const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              username: user
+              pull_number: context.issue.number
             });
 
-            if (!["admin", "write"].includes(perm.data.permission)) return;
+            const allowed = ["feature", "patch", "build"];
 
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ["patch"]
-            });
+            const labels = pr.data.labels
+              .map(l => l.name)
+              .filter(l => allowed.includes(l));
 
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Enable feature label
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const body = context.payload.comment.body.trim();
-            if (body !== "\\build") return;
-
-            const user = context.payload.comment.user.login;
-
-            const perm = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: user
-            });
-
-            if (!["admin", "write"].includes(perm.data.permission)) return;
-
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ["build"]
-            });
+            if (labels.length !== 1) {
+              core.setFailed(`Must have exactly one version label. Found: ${labels.join(", ")}`);
+            }

--- a/.github/workflows/COMMENTS.yml
+++ b/.github/workflows/COMMENTS.yml
@@ -18,13 +18,17 @@ jobs:
           script: |
             const body = context.payload.comment.body.trim();
 
+            const body = context.payload.comment.body.trim().toLowerCase();
+
+            const command = body.replace(/^\\/, "");
+
             const mapping = {
-              "\\feature": "feature",
-              "\\patch": "patch",
-              "\\build": "build"
+              feature: "feature",
+              patch: "patch",
+              build: "build"
             };
 
-            const label = mapping[body];
+            const label = mapping[command];
             if (!label) return;
 
             const user = context.payload.comment.user.login;
@@ -60,12 +64,16 @@ jobs:
             for (const existing of issue.data.labels.map(l => l.name)) {
               if (!versionLabels.includes(existing)) continue;
 
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: repo,
-                issue_number,
-                name: existing
-              });
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  name: existing
+                });
+              } catch (e) {
+                console.log(`Could not remove label: ${existing}`, e.message);
+              }
             }
 
             // apply new label

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -2,7 +2,7 @@ name: Label Validation
 
 on:
   pull_request:
-    types: [opened, edited, reopened, labeled, unlabeled]
+    types: [opened, edited, reopened]
 
 concurrency:
   group: pr-${{ github.event.pull_request.number }}
@@ -49,14 +49,12 @@ jobs:
             // decide new label
             let newLabel = null;
 
-            if (
-              title.startsWith("fix") ||
-              title.startsWith("patch")
-            ) {
+            if (title.startsWith("fix") || title.startsWith("bug")) {
               newLabel = "patch";
             } else if (
               title.startsWith("feat") ||
-              title.startsWith("feature")
+              title.startsWith("feature") ||
+              title.startsWith("add")
             ) {
               newLabel = "feature";
             } else if (
@@ -82,39 +80,14 @@ jobs:
 
             console.log("Applied label:", newLabel);
 
-  check-label:
-    needs: label
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Validate labels
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-
-            const allowed = ["feature", "patch", "build"];
-
-            const labels = pr.data.labels
-              .map(l => l.name)
-              .filter(l => allowed.includes(l));
-
-            if (labels.length !== 1) {
-              core.setFailed(`Must have exactly one version label. Found: ${labels.join(", ")}`);
-            }
   build:
-    needs: check-label
     strategy:
       matrix:
         os: [ubuntu-latest]
         #os: [ubuntu-22.04, ubuntu-latest, macos-latest] # Usable when we also have execution scripts available
-    
-    runs-on: ${{ matrix.os }}
 
+    runs-on: ${{ matrix.os }}
+    
     steps:
       # Check out the repository main folder
       - uses: actions/checkout@v4

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -2,85 +2,45 @@ name: Label Validation
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+    types: [opened, edited, reopened, labeled, unlabeled, synchronize]
 
 concurrency:
   group: pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  label:
+  check-PR-label:
+
     runs-on: ubuntu-latest
-    
-    permissions:
-      issues: write
-      pull-requests: write
 
     steps:
-      - name: Assign label
+      - name: Validate labels
         uses: actions/github-script@v7
         with:
           script: |
-            const versionLabels = ["feature", "patch", "build"];
-
-            const title = context.payload.pull_request.title.toLowerCase();
-
-            // fetch current labels
-            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+            const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number
+              pull_number: context.issue.number
             });
 
-            const currentLabels = labels.map(l => l.name);
+            const allowed = ["feature", "patch", "build"];
 
-            // remove existing version labels
-            for (const l of currentLabels) {
-              if (versionLabels.includes(l)) {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  name: l
-                });
-              }
+            const labels = pr.data.labels
+              .map(l => l.name)
+              .filter(l => allowed.includes(l));
+
+            // deterministic rule
+            if (labels.length !== 1) {
+              core.setFailed(
+                `PR must have exactly ONE version label (feature/patch/build). Found: ${labels.join(", ")}`
+              );
+              throw new Error("Invalid label state");
             }
-
-            // decide new label
-            let newLabel = null;
-
-            if (title.startsWith("fix") || title.startsWith("bug")) {
-              newLabel = "patch";
-            } else if (
-              title.startsWith("feat") ||
-              title.startsWith("feature") ||
-              title.startsWith("add")
-            ) {
-              newLabel = "feature";
-            } else if (
-              title.startsWith("build") ||
-              title.startsWith("pkg") ||
-              title.startsWith("docs")
-            ) {
-              newLabel = "build";
-            }
-
-            if (!newLabel) {
-              console.log("No version label matched");
-              return;
-            }
-
-            // add new label
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: [newLabel]
-            });
-
-            console.log("Applied label:", newLabel);
 
   build:
+    needs: check-PR-label
+
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -92,19 +52,50 @@ jobs:
       # Check out the repository main folder
       - uses: actions/checkout@v4
 
+      - name: Check ready + version state
+        id: gate
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            const labels = pr.data.labels.map(l => l.name);
+
+            const hasReady = labels.includes("ready");
+            const hasVersion = ["feature","patch","build"]
+              .filter(l => labels.includes(l))
+              .length === 1;
+
+            return (hasReady && hasVersion) ? "true" : "false";
+
+      - name: Stop if not ready
+        if: steps.gate.outputs.result != 'true'
+        run: |
+          echo "Not ready or invalid state"
+          exit 0
+
+
       - name: Setup Micromamba
+        if: steps.gate.outputs.result != 'true'
         uses: mamba-org/setup-micromamba@v2
         with:
           environment-name: test-env
           init-shell: bash
 
       - name: Install dependencies
+        if: steps.gate.outputs.result != 'true'
         shell: bash -l {0}
         run: |
           micromamba install conda --yes
           pip install .
 
       - name: Import test
+        if: steps.gate.outputs.result != 'true'
         shell: bash -l {0}
         run: |
           python -c "import mmaseq; print(mmaseq.__version__)"

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -49,12 +49,14 @@ jobs:
             // decide new label
             let newLabel = null;
 
-            if (title.startsWith("fix") || title.startsWith("bug")) {
+            if (
+              title.startsWith("fix") ||
+              title.startsWith("patch")
+            ) {
               newLabel = "patch";
             } else if (
               title.startsWith("feat") ||
-              title.startsWith("feature") ||
-              title.startsWith("add")
+              title.startsWith("feature")
             ) {
               newLabel = "feature";
             } else if (

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -2,11 +2,11 @@ name: Label Validation
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
 
 concurrency:
   group: pr-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   label:
@@ -107,4 +107,4 @@ jobs:
       - name: Import test
         shell: bash -l {0}
         run: |
-          python -c "import mmaseq"
+          python -c "import mmaseq; print(mmaseq.__version__)"

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -52,7 +52,7 @@ jobs:
       # Check out the repository main folder
       - uses: actions/checkout@v4
 
-      - name: Check ready + version state
+      - name: Check version state
         id: gate
         uses: actions/github-script@v7
         with:
@@ -66,36 +66,26 @@ jobs:
 
             const labels = pr.data.labels.map(l => l.name);
 
-            const hasReady = labels.includes("ready");
             const hasVersion = ["feature","patch","build"]
               .filter(l => labels.includes(l))
               .length === 1;
 
-            return (hasReady && hasVersion) ? "true" : "false";
-
-      - name: Stop if not ready
-        if: steps.gate.outputs.result != 'true'
-        run: |
-          echo "Not ready or invalid state"
-          exit 0
+            return (hasVersion) ? "true" : "false";
 
 
       - name: Setup Micromamba
-        if: steps.gate.outputs.result != 'true'
         uses: mamba-org/setup-micromamba@v2
         with:
           environment-name: test-env
           init-shell: bash
 
       - name: Install dependencies
-        if: steps.gate.outputs.result != 'true'
         shell: bash -l {0}
         run: |
           micromamba install conda --yes
           pip install .
 
       - name: Import test
-        if: steps.gate.outputs.result != 'true'
         shell: bash -l {0}
         run: |
           python -c "import mmaseq; print(mmaseq.__version__)"


### PR DESCRIPTION
This workflow automatically adds labels to issues based on comment content. It supports labels for 'feature', 'patch', and 'build' based on user permissions.

Labels can't be removed from comments though, so fixing title is still the main way of handling multiple versioning labels issue