### PR TITLE
Added custom species config flag

### DIFF
--- a/src/mmaseq/deploy.py
+++ b/src/mmaseq/deploy.py
@@ -36,8 +36,7 @@ def parse_deploy():
             "used during pipeline execution. To reinstall environments "
             "and/or databases, remove the `conda/` and/or the `Databases/` "
             "folders in the deployment directory. (Default: %(default)s)"
-        )
-            
+        )        
     )
 
     parser.add_argument(
@@ -49,6 +48,17 @@ def parse_deploy():
             "(Default: %(default)s) The small dataset consists of a single "
             "isolate, executed on ALL modules, thus all results should be "
             f"considered wrong. Read data will be downloaded to {READ_DIR}"
+        )
+    )
+
+    parser.add_argument(
+        "--custom",
+        dest="custom",
+        action="store_true",
+        help=(
+            "Enable custom species configuration. (Default: %(default)s) "
+            "When enabled, species configuration folders (identified as species_configs/ inside the deploy_dir/) will be used. "
+            "If the folder doesn't allready exists, it will be copied from the install folder to the deployment directory."
         )
     )
 
@@ -131,7 +141,7 @@ def deploy_spe_configs(deploy_dir):
         f"deploy_dir = {deploy_dir}"
         ")"))
 
-    spe_configs_dir = deploy_dir / "spe_configs"
+    spe_configs_dir = deploy_dir / "species_configs"
     
     logger.trace("Checking whether config dir allready exists")
     if not spe_configs_dir.exists():
@@ -318,13 +328,15 @@ def deploy(args):
 
     deploy_dir = Path(args.deploy_dir)
     update = args.update
+    custom = args.custom
     test = args.test
     retries = args.retries
     threads = args.threads
     verbosity = args.verbosity
 
-    logger.info("Inspecting species configuration directory")
-    deploy_spe_configs(deploy_dir)
+    if custom
+        logger.info("Inspecting species configuration directory")
+        deploy_spe_configs(deploy_dir)
 
     if not test:
         logger.info(f"Inspecting the deployment dataset")

--- a/src/mmaseq/deploy.py
+++ b/src/mmaseq/deploy.py
@@ -334,7 +334,7 @@ def deploy(args):
     threads = args.threads
     verbosity = args.verbosity
 
-    if custom
+    if custom:
         logger.info("Inspecting species configuration directory")
         deploy_spe_configs(deploy_dir)
 

--- a/src/mmaseq/mmaseq.py
+++ b/src/mmaseq/mmaseq.py
@@ -93,6 +93,17 @@ def parse_mmaseq():
     )
 
     parser.add_argument(
+        "--custom",
+        dest="custom",
+        action="store_true",
+        help=(
+            "Enable custom species configuration. (Default: %(default)s) "
+            "When enabled, species configuration folders (identified as species_configs/ inside the deploy_dir/) will be used. "
+            "If the folder doesn't allready exists, MMAseq will throw an error and exit."
+        )
+    )
+
+    parser.add_argument(
         "--force",
         dest="force",
         action="store_true",
@@ -447,6 +458,7 @@ def mmaseq(args):
     threads = args.threads
     resolve = args.resolve
     clean = args.clean
+    custom = args.custom
     force = args.force
     ignore_assemblies = args.ignore_assemblies
 
@@ -473,16 +485,17 @@ def mmaseq(args):
         samplesheet_file = resolve_samplesheet_paths(samplesheet_file, outdir)
         logger.info("Resolved the file paths stated in the samplesheet")
 
-    spe_configs_dir = deploy_dir / "spe_configs"
+    spe_configs_dir = SPE_CONFIGS
+    if custom:
+        spe_configs_dir = deploy_dir / "species_configs"
 
-    if not spe_configs_dir.exists():
-        logger.warning((
-            f"Species configuration folder not detected in {deploy_dir}. "
-            f"Will use system installation configurations.\n"
-            f"To generate your own species configurations folder, run: \n"
-            f"mmadeploy --deploy_dir {deploy_dir} --threads {threads}"
-        ))
-        spe_configs_dir = SPE_CONFIGS
+        if not spe_configs_dir.exists():
+            logger.error((
+                f"Species configuration folder not detected in {deploy_dir}. "
+                f"To generate your own species configurations folder, run: \n"
+                f"mmadeploy --deploy_dir {deploy_dir} --threads {threads}"
+            ))
+            sys.exit(1)
     else:
         logger.info("Species configurations folder successfully detected.")
 


### PR DESCRIPTION
* Added custom flag to mmadeploy, when active mmadeploy will create species_configs/ inside deploy_dir/ if not allready existing
* Added custom flag to mmaseq, when active will expect (or fail) deploy_dir/species_configs/ to exists, and use this instead of install folder configs